### PR TITLE
docs: fixed link to README.md dans docs/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ This is the development version (`beta`) of the Interface Database. It is curren
 
 ## Versions
 
-| Version | Link                                                                                              | Status                                        |
-| ------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| beta    | [database@beta](https://github.com/AntelopeJS/rethinkdb/tree/main/.antelope/output/database/beta) | Waiting validation from community to go in v1 |
-| 1       | _Not yet released_                                                                                | Planned stable release                        |
+| Version | Link                                                                                            | Status                                        |
+| ------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| beta    | [database@beta](https://github.com/AntelopeJS/rethinkdb/tree/main/output/database/beta) | Waiting validation from community to go in v1 |
+| 1       | _Not yet released_                                                                              | Planned stable release                        |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ ajs module imports add database@beta
 Detailed documentation is available in the `docs` directory:
 
 - [Index](./docs/index.md) - Overview and documentation structure
-- [Query Types](./docs/1.query_types/) - Information about table, selection, and other query types
-- [Operations](./docs/2.operations/) - Database, table, and CRUD operations
-- [Results](./docs/3.results/) - Result types and handling
+- [Query Types](./docs/1.query_types/1.index.md) - Information about table, selection, and other query types
+- [Operations](./docs/2.operations/1.index.md) - Database, table, and CRUD operations
+- [Results](./docs/3.results/1.index.md) - Result types and handling
 
 ## Inspiration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ This documentation is organized into the following sections:
   - [4. SingleSelection](./1.query_types/4.single_selection.md) - Working with a single document
   - [5. Stream](./1.query_types/5.stream.md) - Stream operations
   - [6. Feed](./1.query_types/6.feed.md) - Change feeds and live updates
-  - [7. Datum](./1.query_types/7.datum.md) - Working with single values
+  - [7. Query](./1.query_types/7.query.md) - Change feeds and live updates
+  - [8. Datum](./1.query_types/8.datum.md) - Working with single values
 
 - [**2. Operations**](./2.operations/1.index.md) - Common operations:
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed links in `docs/index.md` accordingly to lasts docs updates.
`README.md` is now linking to each `index.md` instead of pointing to the directory containing it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
