### PR TITLE
test: add comprehensive test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^22.19.15",
     "@types/semver": "^7.7.1",
     "chai": "^4.5.0",
-    "mongodb-memory-server-core": "^10.4.3",
+    "mongodb-memory-server-core": "^11.0.1",
     "release-it": "^19.2.4",
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       mongodb-memory-server-core:
-        specifier: ^10.4.3
-        version: 10.4.3(socks@2.8.7)
+        specifier: ^11.0.1
+        version: 11.0.1(socks@2.8.7)
       release-it:
         specifier: ^19.2.4
         version: 19.2.4(@types/node@22.19.15)
@@ -322,8 +322,8 @@ packages:
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
-  '@types/whatwg-url@11.0.5':
-    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -435,9 +435,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  bson@6.10.4:
-    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
-    engines: {node: '>=16.20.1'}
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -906,24 +906,25 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mongodb-connection-string-url@3.0.2:
-    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
 
-  mongodb-memory-server-core@10.4.3:
-    resolution: {integrity: sha512-IPjlw73IoSYopnqBibQKxmAXMbOEPf5uGAOsBcaUiNH/TOI7V19WO+K7n5KYtnQ9FqzLGLpvwCGuPOTBSg4s5Q==}
-    engines: {node: '>=16.20.1'}
+  mongodb-memory-server-core@11.0.1:
+    resolution: {integrity: sha512-IcIb2S9Xf7Lmz43Z1ZujMqNg7PU5Q7yn+4wOnu7l6pfeGPkEmlqzV1hIbroVx8s4vXhPB1oMGC1u8clW7aj3Xw==}
+    engines: {node: '>=20.19.0'}
 
-  mongodb@6.21.0:
-    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
-    engines: {node: '>=16.20.1'}
+  mongodb@7.1.1:
+    resolution: {integrity: sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
-      gcp-metadata: ^5.2.0
-      kerberos: ^2.0.1
-      mongodb-client-encryption: '>=6.0.0 <7'
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
       snappy: ^7.3.2
-      socks: ^2.7.1
+      socks: ^2.8.6
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
@@ -1616,7 +1617,7 @@ snapshots:
 
   '@types/webidl-conversions@7.0.3': {}
 
-  '@types/whatwg-url@11.0.5':
+  '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
@@ -1701,7 +1702,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  bson@6.10.4: {}
+  bson@7.2.0: {}
 
   buffer-crc32@0.2.13: {}
 
@@ -2154,12 +2155,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mongodb-connection-string-url@3.0.2:
+  mongodb-connection-string-url@7.0.1:
     dependencies:
-      '@types/whatwg-url': 11.0.5
+      '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@10.4.3(socks@2.8.7):
+  mongodb-memory-server-core@11.0.1(socks@2.8.7):
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
@@ -2167,7 +2168,7 @@ snapshots:
       find-cache-dir: 3.3.2
       follow-redirects: 1.15.11(debug@4.4.3)
       https-proxy-agent: 7.0.6
-      mongodb: 6.21.0(socks@2.8.7)
+      mongodb: 7.1.1(socks@2.8.7)
       new-find-package-json: 2.0.0
       semver: 7.7.4
       tar-stream: 3.1.8
@@ -2186,11 +2187,11 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb@6.21.0(socks@2.8.7):
+  mongodb@7.1.1(socks@2.8.7):
     dependencies:
       '@mongodb-js/saslprep': 1.4.6
-      bson: 6.10.4
-      mongodb-connection-string-url: 3.0.2
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
     optionalDependencies:
       socks: 2.8.7
 

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/mongodb",
-        version: "1.0.0",
+        version: "1.0.5",
       },
     },
   },

--- a/src/tests/aggregation_operations.test.ts
+++ b/src/tests/aggregation_operations.test.ts
@@ -160,7 +160,7 @@ async function CursorTest() {
   const sortedVehicles = [...vehicles].sort((a, b) => a.price - b.price);
   const cursor = table.orderBy("price", "asc").cursor();
 
-  const results: any[] = [];
+  const results: Vehicle[] = [];
   let next = await cursor.next();
   while (!next.done) {
     results.push(next.value);

--- a/src/tests/aggregation_operations.test.ts
+++ b/src/tests/aggregation_operations.test.ts
@@ -36,6 +36,7 @@ describe("Aggregation & Projection Operations", () => {
   it("Distinct", Distinct);
   it("Distinct Without Field", DistinctWithoutField);
   it("Cursor", CursorTest);
+  it("Pluck on Single Selection", PluckOnSingleSelection);
   it("Cleanup", CleanupTest);
 });
 
@@ -171,6 +172,16 @@ async function CursorTest() {
   results.forEach((doc, i) => {
     expect(doc).to.have.property("price", sortedVehicles[i].price);
   });
+}
+
+async function PluckOnSingleSelection() {
+  const result = await table.get(insertedKeys[0]).pluck("car", "price").run();
+  expect(result).to.be.an("object");
+  expect(result).to.have.property("car");
+  expect(result).to.have.property("price");
+  expect(result).to.not.have.property("manufactured");
+  expect(result).to.not.have.property("isElectric");
+  expect(result).to.not.have.property("kilometers");
 }
 
 async function CleanupTest() {

--- a/src/tests/basic_operations.test.ts
+++ b/src/tests/basic_operations.test.ts
@@ -20,6 +20,8 @@ describe("Basic Operations", () => {
   it("Get All", GetAllTest);
   it("Get By Index", GetAllMultiKeyByIndex);
   it("Get All by primary keys", GetAllMultiKeyByPrimaryKey);
+  it("Get All by 3+ primary keys", GetAllManyPrimaryKeys);
+  it("Get All by 3+ index values", GetAllManyIndexValues);
   it("Get All With OrderBy", GetAllWithOrderBy);
   it("Update", UpdateTest);
   it("Replace", ReplaceTest);
@@ -202,6 +204,37 @@ async function GetAllMultiKeyByPrimaryKey() {
 
   for (const doc of result) {
     expect(targetKeys).to.include(doc._id);
+  }
+}
+
+async function GetAllManyPrimaryKeys() {
+  const targetKeys = [insertedKeys[0], insertedKeys[1], insertedKeys[2]];
+  const result = await table.getAll(targetKeys).run();
+
+  expect(result).to.be.an("array");
+  expect(result).to.have.lengthOf(targetKeys.length);
+
+  for (const doc of result) {
+    expect(targetKeys).to.include(doc._id);
+  }
+}
+
+async function GetAllManyIndexValues() {
+  const targetPrices = [
+    expectedVehicles[0].price,
+    expectedVehicles[1].price,
+    expectedVehicles[2].price,
+  ];
+  const result = await table.getAll(targetPrices, "price").run();
+
+  expect(result).to.be.an("array");
+  const expectedCount = expectedVehicles.filter((v) =>
+    targetPrices.includes(v.price),
+  ).length;
+  expect(result).to.have.lengthOf(expectedCount);
+
+  for (const doc of result) {
+    expect(targetPrices).to.include(doc.price);
   }
 }
 

--- a/src/tests/between_operations.test.ts
+++ b/src/tests/between_operations.test.ts
@@ -3,8 +3,14 @@ import { expect } from "chai";
 import { Vehicle, vehicles } from "./datasets/vehicles";
 
 const tableName = "test-table";
+
+const VehicleWithDateIndex = {
+  ...Vehicle,
+  indexes: { ...Vehicle.indexes, manufactured: {} },
+};
+
 const schema = new Schema<{ [tableName]: Vehicle }>("test-between-operations", {
-  [tableName]: Vehicle,
+  [tableName]: VehicleWithDateIndex,
 });
 const table = schema.instance("default").table(tableName);
 
@@ -26,6 +32,7 @@ describe("Between Operations", () => {
   it("Between All", BetweenAll);
   it("Between Empty", BetweenEmpty);
   it("Between Chained With Filter", BetweenChainedWithFilter);
+  it("Between with Date Field", BetweenWithDateField);
   it("Cleanup", CleanupTest);
 });
 
@@ -76,6 +83,21 @@ async function BetweenChainedWithFilter() {
   expect(result).to.have.lengthOf(expected.length);
   result.forEach((doc) => {
     expect(doc.isElectric).to.equal(true);
+  });
+}
+
+async function BetweenWithDateField() {
+  const low = new Date("2000-01-01");
+  const high = new Date("2010-01-01");
+  const result = await table.between("manufactured", low, high).run();
+  const expected = vehicles.filter(
+    (v) => v.manufactured >= low && v.manufactured < high,
+  );
+  expect(result).to.be.an("array");
+  expect(result).to.have.lengthOf(expected.length);
+  result.forEach((doc) => {
+    expect(doc.manufactured).to.be.gte(low);
+    expect(doc.manufactured).to.be.lt(high);
   });
 }
 

--- a/src/tests/change_feeds.test.ts
+++ b/src/tests/change_feeds.test.ts
@@ -13,6 +13,7 @@ describe("Change Streams", () => {
   it("Insert Event", InsertEventTest);
   it("Update Event", UpdateEventTest);
   it("Delete Event", DeleteEventTest);
+  it("Bulk Insert Events", BulkInsertEventTest);
   before(async () => {
     await schema.createInstance("default").run();
   });
@@ -106,4 +107,36 @@ async function DeleteEventTest() {
   expect(results[0])
     .to.have.property("oldValue")
     .that.has.property("_id", inserted[0]);
+}
+
+async function BulkInsertEventTest() {
+  const newDocs: Vehicle[] = [
+    {
+      car: "Tesla",
+      manufactured: new Date("2023-06-15"),
+      price: 45000,
+      isElectric: true,
+      kilometers: 5000,
+    },
+    {
+      car: "BMW",
+      manufactured: new Date("2021-03-20"),
+      price: 55000,
+      isElectric: false,
+      kilometers: 30000,
+    },
+  ];
+
+  const results = await ReadChanges(table.changes(), async () => {
+    await table.insert(newDocs);
+  });
+
+  expect(results).to.be.an("array").of.length(newDocs.length);
+  results.forEach((entry) => {
+    expect(entry).to.have.property("changeType", "added");
+    expect(entry).to.have.property("newValue");
+  });
+
+  const insertedCars = results.map((r: any) => r.newValue.car).sort();
+  expect(insertedCars).to.deep.equal(["BMW", "Tesla"]);
 }

--- a/src/tests/date_operations.test.ts
+++ b/src/tests/date_operations.test.ts
@@ -31,6 +31,10 @@ describe("Date Operations", () => {
   it("Filter by Epoch Comparison", FilterByEpochComparison);
   it("Filter by Date Greater Than", FilterByDateGreaterThan);
   it("Filter by Date Less Than", FilterByDateLessThan);
+  it("Extract Day of Week", ExtractDayOfWeek);
+  it("Extract Day of Year", ExtractDayOfYear);
+  it("Extract Hours Minutes Seconds", ExtractHoursMinutesSeconds);
+  it("Extract Time of Day", ExtractTimeOfDay);
   it("Cleanup", CleanupTest);
 });
 
@@ -141,6 +145,73 @@ async function FilterByDateLessThan() {
 
   const names = result.map((doc) => doc.name).sort();
   expect(names).to.deep.equal(["Alice", "Dominique"]);
+}
+
+async function ExtractDayOfWeek() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      dow: doc.key("createdAt").dayofweek(),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  expect(result).to.have.lengthOf(testData.length);
+  result.forEach((doc) => {
+    expect(doc.dow).to.be.a("number");
+    expect(doc.dow).to.be.gte(1).and.lte(7);
+  });
+}
+
+async function ExtractDayOfYear() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      doy: doc.key("createdAt").dayofyear(),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  result.forEach((doc) => {
+    expect(doc.doy).to.be.a("number");
+    expect(doc.doy).to.be.gte(1).and.lte(366);
+  });
+}
+
+async function ExtractHoursMinutesSeconds() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      hours: doc.key("createdAt").hours(),
+      minutes: doc.key("createdAt").minutes(),
+      seconds: doc.key("createdAt").seconds(),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  result.forEach((doc) => {
+    expect(doc.hours).to.be.a("number");
+    expect(doc.minutes).to.be.a("number");
+    expect(doc.seconds).to.be.a("number");
+    expect(doc.hours).to.be.gte(0).and.lt(24);
+    expect(doc.minutes).to.be.gte(0).and.lt(60);
+    expect(doc.seconds).to.be.gte(0).and.lt(60);
+  });
+}
+
+async function ExtractTimeOfDay() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      tod: doc.key("createdAt").timeofday(),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  result.forEach((doc) => {
+    expect(doc.tod).to.be.a("number");
+    expect(doc.tod).to.be.gte(0).and.lt(86400);
+  });
 }
 
 async function CleanupTest() {

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -31,6 +31,9 @@ describe("Do Operations", () => {
   it("Do with Conditional Logic", DoWithConditionalLogic);
   it("Do with Array Operations", DoWithArrayOperations);
   it("Do with Nested Object Operations", DoWithNestedObjectOperations);
+  it("Do with Subquery Field Reference", DoWithSubqueryFieldReference);
+  it("Do with Unresolved Subquery Returns Null", DoWithUnresolvedSubqueryReturnsNull);
+  it("Do with No Temporary Lookup Fields", DoWithNoTemporaryLookupFields);
   it("Cleanup", CleanupTest);
 });
 
@@ -236,6 +239,62 @@ async function DoWithNestedObjectOperations() {
     expect(result.profile.metadata.preferences.theme).to.equal("dark");
   }
   expect(result.profile.metadata.tags).to.include("experienced");
+}
+
+async function DoWithSubqueryFieldReference() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) =>
+      doc.merge({
+        lookedUpUser: table.getAll(doc.key("email") as any, "email").nth(0),
+      }),
+    )
+    .run();
+
+  expect(result).to.be.an("object");
+  expect(result).to.have.property("name", "Antoine");
+  expect(result).to.have.property("lookedUpUser");
+  expect(result.lookedUpUser).to.be.an("object");
+  expect(result.lookedUpUser).to.have.property("name", "Antoine");
+  expect(result.lookedUpUser).to.have.property("email", "antoine@example.com");
+  expect(result.lookedUpUser).to.have.property("age", 25);
+}
+
+async function DoWithUnresolvedSubqueryReturnsNull() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      missing: table.get("nonexistent-id-12345"),
+    }))
+    .run();
+
+  expect(result).to.be.an("object");
+  expect(result).to.have.property("name", "Antoine");
+  expect(result).to.have.property("missing");
+  expect(result.missing).to.equal(null);
+}
+
+async function DoWithNoTemporaryLookupFields() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      email: doc.key("email"),
+      resolvedUser: table.getAll(doc.key("email") as any, "email").nth(0),
+    }))
+    .run();
+
+  expect(result).to.be.an("object");
+  const keys = Object.keys(result);
+  const temporaryKeys = keys.filter(
+    (k) => k.startsWith("temporary_") || k.includes("_lookup_"),
+  );
+  expect(temporaryKeys).to.have.lengthOf(0);
+  expect(result).to.have.property("name", "Antoine");
+  expect(result).to.have.property("email", "antoine@example.com");
+  expect(result).to.have.property("resolvedUser");
+  expect(result.resolvedUser).to.be.an("object");
 }
 
 async function CleanupTest() {

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -34,6 +34,13 @@ describe("Do Operations", () => {
   it("Do with Subquery Field Reference", DoWithSubqueryFieldReference);
   it("Do with Unresolved Subquery Returns Null", DoWithUnresolvedSubqueryReturnsNull);
   it("Do with No Temporary Lookup Fields", DoWithNoTemporaryLookupFields);
+  it("Do with sub()", DoWithSub);
+  it("Do with div()", DoWithDiv);
+  it("Do with mod()", DoWithMod);
+  it("Do with ceil() and floor()", DoWithCeilFloor);
+  it("Do with Bitwise Operations", DoWithBitwiseOperations);
+  it("Do with Array ValueProxy Operations", DoWithArrayValueProxyOps);
+  it("Do with Object keys() and values()", DoWithObjectKeysValues);
   it("Cleanup", CleanupTest);
 });
 
@@ -295,6 +302,114 @@ async function DoWithNoTemporaryLookupFields() {
   expect(result).to.have.property("email", "antoine@example.com");
   expect(result).to.have.property("resolvedUser");
   expect(result.resolvedUser).to.be.an("object");
+}
+
+async function DoWithSub() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      ageMinus5: doc.key("age").sub(5),
+    }))
+    .run();
+  expect(result.name).to.equal("Antoine");
+  expect(result.ageMinus5).to.equal(testData[0].age - 5);
+}
+
+async function DoWithDiv() {
+  const result = await table
+    .get(insertedKeys[3])
+    .do((doc) => ({
+      name: doc.key("name"),
+      monthlySalary: doc.key("salary").div(12),
+    }))
+    .run();
+  expect(result.name).to.equal("Dominique");
+  expect(result.monthlySalary).to.equal(testData[3].salary! / 12);
+}
+
+async function DoWithMod() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      ageMod10: doc.key("age").mod(10),
+    }))
+    .run();
+  expect(result.name).to.equal("Antoine");
+  expect(result.ageMod10).to.equal(testData[0].age % 10);
+}
+
+async function DoWithCeilFloor() {
+  const result = await table
+    .get(insertedKeys[3])
+    .do((doc) => ({
+      name: doc.key("name"),
+      salaryDivCeil: doc.key("salary").div(7).ceil(),
+      salaryDivFloor: doc.key("salary").div(7).floor(),
+    }))
+    .run();
+  expect(result.name).to.equal("Dominique");
+  expect(result.salaryDivCeil).to.equal(Math.ceil(testData[3].salary! / 7));
+  expect(result.salaryDivFloor).to.equal(Math.floor(testData[3].salary! / 7));
+}
+
+async function DoWithBitwiseOperations() {
+  const level = testData[0].metadata!.level!;
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      band: doc.key("metadata").key("level").band(3),
+      bor: doc.key("metadata").key("level").bor(8),
+      bxor: doc.key("metadata").key("level").bxor(1),
+      bnot: doc.key("metadata").key("level").bnot(),
+      blshift: doc.key("metadata").key("level").blshift(2),
+      brshift: doc.key("metadata").key("level").brshift(1),
+    }))
+    .run();
+  expect(result.name).to.equal("Antoine");
+  expect(result.band).to.equal(level & 3);
+  expect(result.bor).to.equal(level | 8);
+  expect(result.bxor).to.equal(level ^ 1);
+  expect(result.bnot).to.equal(~level);
+  expect(result.blshift).to.equal(level << 2);
+  expect(result.brshift).to.equal(level >> 1);
+}
+
+async function DoWithArrayValueProxyOps() {
+  const skills = testData[0].skills!;
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      firstSkill: doc.key("skills").index(0),
+      sliced: doc.key("skills").slice(0, 2),
+      skillCount: doc.key("skills").count(),
+    }))
+    .run();
+  expect(result.name).to.equal("Antoine");
+  expect(result.firstSkill).to.equal(skills[0]);
+  expect(result.sliced).to.deep.equal(skills.slice(0, 2));
+  expect(result.skillCount).to.equal(skills.length);
+}
+
+async function DoWithObjectKeysValues() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => ({
+      name: doc.key("name"),
+      metaKeys: doc.key("metadata").keys(),
+      metaValues: doc.key("metadata").values(),
+    }))
+    .run();
+  expect(result.name).to.equal("Antoine");
+  expect(result.metaKeys).to.be.an("array");
+  expect(result.metaKeys).to.include("level");
+  expect(result.metaKeys).to.include("tags");
+  expect(result.metaKeys).to.include("preferences");
+  expect(result.metaValues).to.be.an("array");
+  expect(result.metaValues).to.have.lengthOf(result.metaKeys.length);
 }
 
 async function CleanupTest() {

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -329,7 +329,7 @@ async function DoWithDiv() {
     }))
     .run();
   expect(result.name).to.equal("Dominique");
-  expect(result.monthlySalary).to.equal(testData[3].salary! / 12);
+  expect(result.monthlySalary).to.equal((testData[3].salary ?? 0) / 12);
 }
 
 async function DoWithMod() {
@@ -354,12 +354,12 @@ async function DoWithCeilFloor() {
     }))
     .run();
   expect(result.name).to.equal("Dominique");
-  expect(result.salaryDivCeil).to.equal(Math.ceil(testData[3].salary! / 7));
-  expect(result.salaryDivFloor).to.equal(Math.floor(testData[3].salary! / 7));
+  expect(result.salaryDivCeil).to.equal(Math.ceil((testData[3].salary ?? 0) / 7));
+  expect(result.salaryDivFloor).to.equal(Math.floor((testData[3].salary ?? 0) / 7));
 }
 
 async function DoWithBitwiseOperations() {
-  const level = testData[0].metadata!.level!;
+  const level = testData[0].metadata?.level ?? 0;
   const result = await table
     .get(insertedKeys[0])
     .do((doc) => ({
@@ -382,7 +382,7 @@ async function DoWithBitwiseOperations() {
 }
 
 async function DoWithArrayValueProxyOps() {
-  const skills = testData[0].skills!;
+  const skills = testData[0].skills ?? [];
   const result = await table
     .get(insertedKeys[0])
     .do((doc) => ({
@@ -432,7 +432,7 @@ async function DoWithDynamicKeyAccess() {
     .run();
 
   expect(result.name).to.equal("Antoine");
-  const expectedTheme = testData[0].metadata!.preferences!.theme;
+  const expectedTheme = testData[0].metadata?.preferences?.theme;
   expect(result.staticTheme).to.equal(expectedTheme);
   expect(result.dynamicTheme).to.equal(expectedTheme);
 }

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -354,8 +354,12 @@ async function DoWithCeilFloor() {
     }))
     .run();
   expect(result.name).to.equal("Dominique");
-  expect(result.salaryDivCeil).to.equal(Math.ceil((testData[3].salary ?? 0) / 7));
-  expect(result.salaryDivFloor).to.equal(Math.floor((testData[3].salary ?? 0) / 7));
+  expect(result.salaryDivCeil).to.equal(
+    Math.ceil((testData[3].salary ?? 0) / 7),
+  );
+  expect(result.salaryDivFloor).to.equal(
+    Math.floor((testData[3].salary ?? 0) / 7),
+  );
 }
 
 async function DoWithBitwiseOperations() {

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@antelopejs/interface-database";
+import { Schema, ValueProxy } from "@antelopejs/interface-database";
 import { expect } from "chai";
 import { getUniqueUsers, User } from "./datasets/users";
 
@@ -32,7 +32,10 @@ describe("Do Operations", () => {
   it("Do with Array Operations", DoWithArrayOperations);
   it("Do with Nested Object Operations", DoWithNestedObjectOperations);
   it("Do with Subquery Field Reference", DoWithSubqueryFieldReference);
-  it("Do with Unresolved Subquery Returns Null", DoWithUnresolvedSubqueryReturnsNull);
+  it(
+    "Do with Unresolved Subquery Returns Null",
+    DoWithUnresolvedSubqueryReturnsNull,
+  );
   it("Do with No Temporary Lookup Fields", DoWithNoTemporaryLookupFields);
   it("Do with sub()", DoWithSub);
   it("Do with div()", DoWithDiv);
@@ -41,6 +44,7 @@ describe("Do Operations", () => {
   it("Do with Bitwise Operations", DoWithBitwiseOperations);
   it("Do with Array ValueProxy Operations", DoWithArrayValueProxyOps);
   it("Do with Object keys() and values()", DoWithObjectKeysValues);
+  it("Do with Dynamic Key Access", DoWithDynamicKeyAccess);
   it("Cleanup", CleanupTest);
 });
 
@@ -410,6 +414,27 @@ async function DoWithObjectKeysValues() {
   expect(result.metaKeys).to.include("preferences");
   expect(result.metaValues).to.be.an("array");
   expect(result.metaValues).to.have.lengthOf(result.metaKeys.length);
+}
+
+async function DoWithDynamicKeyAccess() {
+  const result = await table
+    .get(insertedKeys[0])
+    .do((doc) => {
+      const prefs = doc.key("metadata").key("preferences");
+      return {
+        name: doc.key("name"),
+        staticTheme: prefs.key("theme"),
+        dynamicTheme: prefs.key(
+          ValueProxy.constant({ dummy: "theme" as const }).key("dummy"),
+        ),
+      };
+    })
+    .run();
+
+  expect(result.name).to.equal("Antoine");
+  const expectedTheme = testData[0].metadata!.preferences!.theme;
+  expect(result.staticTheme).to.equal(expectedTheme);
+  expect(result.dynamicTheme).to.equal(expectedTheme);
 }
 
 async function CleanupTest() {

--- a/src/tests/filters.test.ts
+++ b/src/tests/filters.test.ts
@@ -32,6 +32,19 @@ describe("Filter Operations", () => {
   it("Filter with Constant Array", FilterWithConstantArray);
   it("Filter with Array Field Filter", FilterWithArrayFieldFilter);
   it("Filter with Array Field Map", FilterWithArrayFieldMap);
+  it("Filter with ge()", FilterWithGe);
+  it("Filter with le()", FilterWithLe);
+  it("Filter with and()", FilterWithAnd);
+  it("Filter with or()", FilterWithOr);
+  it("Filter with not()", FilterWithNot);
+  it("Filter with downcase()", FilterWithDowncase);
+  it("Filter with strlen()", FilterWithStrlen);
+  it("Filter with match()", FilterWithMatch);
+  it("Filter with concat()", FilterWithConcat);
+  it("Filter with Array isempty()", FilterWithArrayIsempty);
+  it("Filter with Array index()", FilterWithArrayIndex);
+  it("Filter with Object hasfields()", FilterWithObjectHasfields);
+  it("Filter with Object keys()", FilterWithObjectKeys);
   it("Cleanup", CleanupTest);
 });
 
@@ -198,6 +211,139 @@ async function FilterWithArrayFieldMap() {
       expect(skill).to.equal(skill.toUpperCase());
     }
   }
+}
+
+async function FilterWithGe() {
+  const result = await table.filter((doc) => doc.key("age").ge(25)).run();
+  const expected = testData.filter((u) => u.age >= 25);
+  expect(result).to.have.lengthOf(expected.length);
+  result.forEach((doc) => expect(doc.age).to.be.gte(25));
+}
+
+async function FilterWithLe() {
+  const result = await table.filter((doc) => doc.key("age").le(25)).run();
+  const expected = testData.filter((u) => u.age <= 25);
+  expect(result).to.have.lengthOf(expected.length);
+  result.forEach((doc) => expect(doc.age).to.be.lte(25));
+}
+
+async function FilterWithAnd() {
+  const result = await table
+    .filter((doc) =>
+      doc.key("isActive").eq(true).and(doc.key("age").gt(25)),
+    )
+    .run();
+  const expected = testData.filter((u) => u.isActive && u.age > 25);
+  expect(result).to.have.lengthOf(expected.length);
+  result.forEach((doc) => {
+    expect(doc.isActive).to.equal(true);
+    expect(doc.age).to.be.greaterThan(25);
+  });
+}
+
+async function FilterWithOr() {
+  const result = await table
+    .filter((doc) =>
+      doc
+        .key("department")
+        .eq("Development")
+        .or(doc.key("department").eq("Marketing")),
+    )
+    .run();
+  const expected = testData.filter(
+    (u) => u.department === "Development" || u.department === "Marketing",
+  );
+  expect(result).to.have.lengthOf(expected.length);
+}
+
+async function FilterWithNot() {
+  const result = await table
+    .filter((doc) => doc.key("isActive").not())
+    .run();
+  const expected = testData.filter((u) => !u.isActive);
+  expect(result).to.have.lengthOf(expected.length);
+  result.forEach((doc) => expect(doc.isActive).to.equal(false));
+}
+
+async function FilterWithDowncase() {
+  const result = await table
+    .filter((doc) => doc.key("name").downcase().eq("antoine"))
+    .run();
+  expect(result).to.have.lengthOf(1);
+  expect(result[0].name).to.equal("Antoine");
+}
+
+async function FilterWithStrlen() {
+  const result = await table
+    .filter((doc) => doc.key("name").strlen().gt(6))
+    .run();
+  const expected = testData.filter((u) => u.name.length > 6);
+  expect(result).to.have.lengthOf(expected.length);
+}
+
+async function FilterWithMatch() {
+  const result = await table
+    .filter((doc) => doc.key("email").match("^a.*@example\\.com$"))
+    .run();
+  const expected = testData.filter((u) =>
+    /^a.*@example\.com$/.test(u.email ?? ""),
+  );
+  expect(result).to.have.lengthOf(expected.length);
+}
+
+async function FilterWithConcat() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      greeting: doc.key("name").concat(" Hello"),
+    }))
+    .filter((doc) => doc.key("greeting").eq("Antoine Hello"))
+    .run();
+  expect(result).to.have.lengthOf(1);
+  expect(result[0].greeting).to.equal("Antoine Hello");
+}
+
+async function FilterWithArrayIsempty() {
+  const result = await table
+    .filter((doc) => doc.key("skills").isempty().eq(false))
+    .run();
+  const expected = testData.filter(
+    (u) => (u.skills ?? []).length > 0,
+  );
+  expect(result).to.have.lengthOf(expected.length);
+}
+
+async function FilterWithArrayIndex() {
+  const result = await table
+    .filter((doc) => doc.key("skills").index(0).eq("JavaScript"))
+    .run();
+  const expected = testData.filter(
+    (u) => (u.skills ?? [])[0] === "JavaScript",
+  );
+  expect(result).to.have.lengthOf(expected.length);
+  expect(result[0].name).to.equal("Antoine");
+}
+
+async function FilterWithObjectHasfields() {
+  const result = await table
+    .filter((doc) => doc.key("metadata").hasfields("level", "tags"))
+    .run();
+  const expected = testData.filter(
+    (u) => u.metadata?.level !== undefined && u.metadata?.tags !== undefined,
+  );
+  expect(result).to.have.lengthOf(expected.length);
+}
+
+async function FilterWithObjectKeys() {
+  const result = await table
+    .map((doc) => ({
+      name: doc.key("name"),
+      metaKeyCount: doc.key("metadata").keys().count(),
+    }))
+    .filter((doc) => doc.key("metaKeyCount").gt(0))
+    .run();
+  expect(result).to.have.lengthOf(testData.length);
+  result.forEach((doc) => expect(doc.metaKeyCount).to.be.greaterThan(0));
 }
 
 async function CleanupTest() {

--- a/src/tests/filters.test.ts
+++ b/src/tests/filters.test.ts
@@ -332,6 +332,13 @@ async function FilterWithObjectHasfields() {
     (u) => u.metadata?.level !== undefined && u.metadata?.tags !== undefined,
   );
   expect(result).to.have.lengthOf(expected.length);
+
+  const noMatch = await table
+    .filter((doc) =>
+      doc.key("metadata").hasfields("level", "nonexistentField"),
+    )
+    .run();
+  expect(noMatch).to.have.lengthOf(0);
 }
 
 async function FilterWithObjectKeys() {

--- a/src/tests/filters.test.ts
+++ b/src/tests/filters.test.ts
@@ -217,21 +217,23 @@ async function FilterWithGe() {
   const result = await table.filter((doc) => doc.key("age").ge(25)).run();
   const expected = testData.filter((u) => u.age >= 25);
   expect(result).to.have.lengthOf(expected.length);
-  result.forEach((doc) => expect(doc.age).to.be.gte(25));
+  result.forEach((doc) => {
+    expect(doc.age).to.be.gte(25);
+  });
 }
 
 async function FilterWithLe() {
   const result = await table.filter((doc) => doc.key("age").le(25)).run();
   const expected = testData.filter((u) => u.age <= 25);
   expect(result).to.have.lengthOf(expected.length);
-  result.forEach((doc) => expect(doc.age).to.be.lte(25));
+  result.forEach((doc) => {
+    expect(doc.age).to.be.lte(25);
+  });
 }
 
 async function FilterWithAnd() {
   const result = await table
-    .filter((doc) =>
-      doc.key("isActive").eq(true).and(doc.key("age").gt(25)),
-    )
+    .filter((doc) => doc.key("isActive").eq(true).and(doc.key("age").gt(25)))
     .run();
   const expected = testData.filter((u) => u.isActive && u.age > 25);
   expect(result).to.have.lengthOf(expected.length);
@@ -257,12 +259,12 @@ async function FilterWithOr() {
 }
 
 async function FilterWithNot() {
-  const result = await table
-    .filter((doc) => doc.key("isActive").not())
-    .run();
+  const result = await table.filter((doc) => doc.key("isActive").not()).run();
   const expected = testData.filter((u) => !u.isActive);
   expect(result).to.have.lengthOf(expected.length);
-  result.forEach((doc) => expect(doc.isActive).to.equal(false));
+  result.forEach((doc) => {
+    expect(doc.isActive).to.equal(false);
+  });
 }
 
 async function FilterWithDowncase() {
@@ -307,9 +309,7 @@ async function FilterWithArrayIsempty() {
   const result = await table
     .filter((doc) => doc.key("skills").isempty().eq(false))
     .run();
-  const expected = testData.filter(
-    (u) => (u.skills ?? []).length > 0,
-  );
+  const expected = testData.filter((u) => (u.skills ?? []).length > 0);
   expect(result).to.have.lengthOf(expected.length);
 }
 
@@ -317,9 +317,7 @@ async function FilterWithArrayIndex() {
   const result = await table
     .filter((doc) => doc.key("skills").index(0).eq("JavaScript"))
     .run();
-  const expected = testData.filter(
-    (u) => (u.skills ?? [])[0] === "JavaScript",
-  );
+  const expected = testData.filter((u) => (u.skills ?? [])[0] === "JavaScript");
   expect(result).to.have.lengthOf(expected.length);
   expect(result[0].name).to.equal("Antoine");
 }
@@ -334,9 +332,7 @@ async function FilterWithObjectHasfields() {
   expect(result).to.have.lengthOf(expected.length);
 
   const noMatch = await table
-    .filter((doc) =>
-      doc.key("metadata").hasfields("level", "nonexistentField"),
-    )
+    .filter((doc) => doc.key("metadata").hasfields("level", "nonexistentField"))
     .run();
   expect(noMatch).to.have.lengthOf(0);
 }
@@ -350,7 +346,9 @@ async function FilterWithObjectKeys() {
     .filter((doc) => doc.key("metaKeyCount").gt(0))
     .run();
   expect(result).to.have.lengthOf(testData.length);
-  result.forEach((doc) => expect(doc.metaKeyCount).to.be.greaterThan(0));
+  result.forEach((doc) => {
+    expect(doc.metaKeyCount).to.be.greaterThan(0);
+  });
 }
 
 async function CleanupTest() {

--- a/src/tests/group_operations.test.ts
+++ b/src/tests/group_operations.test.ts
@@ -46,6 +46,7 @@ describe("Group Operations", () => {
     "Group by Payment Status with Multiple Aggregations",
     GroupByPaymentStatusWithMultipleAggregations,
   );
+  it("Group with Distinct in Callback", GroupWithDistinctInCallback);
   it("Cleanup", CleanupTest);
 });
 
@@ -262,6 +263,48 @@ async function GroupByPaymentStatusWithMultipleAggregations() {
 
   expect(paidGroup?.totalRevenue).to.equal(expectedPaidRevenue);
   expect(unpaidGroup?.totalRevenue).to.equal(expectedUnpaidRevenue);
+}
+
+async function GroupWithDistinctInCallback() {
+  const result = await table
+    .group("deliveryType", (stream, group) => ({
+      deliveryType: group,
+      uniqueCustomers: stream.distinct("customerName"),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  const expectedGroupCount = new Set(
+    testData.map((order) => order.deliveryType),
+  ).size;
+  expect(result).to.have.lengthOf(expectedGroupCount);
+
+  const expressGroup = result.find((item) => item.deliveryType === "express");
+  const standardGroup = result.find((item) => item.deliveryType === "standard");
+
+  const expectedExpressCustomers = [
+    ...new Set(
+      testData
+        .filter((o) => o.deliveryType === "express")
+        .map((o) => o.customerName),
+    ),
+  ];
+  const expectedStandardCustomers = [
+    ...new Set(
+      testData
+        .filter((o) => o.deliveryType === "standard")
+        .map((o) => o.customerName),
+    ),
+  ];
+
+  expect(expressGroup?.uniqueCustomers).to.be.an("array");
+  expect(expressGroup?.uniqueCustomers).to.have.lengthOf(
+    expectedExpressCustomers.length,
+  );
+  expect(standardGroup?.uniqueCustomers).to.be.an("array");
+  expect(standardGroup?.uniqueCustomers).to.have.lengthOf(
+    expectedStandardCustomers.length,
+  );
 }
 
 async function CleanupTest() {

--- a/src/tests/group_operations.test.ts
+++ b/src/tests/group_operations.test.ts
@@ -324,18 +324,18 @@ async function GroupWithMinAndMax() {
   expect(result).to.have.lengthOf(expectedGroupCount);
 
   const expressGroup = result.find((item) => item.deliveryType === "express");
-  const expressOrders = testData.filter(
-    (o) => o.deliveryType === "express",
+  const expressOrders = testData.filter((o) => o.deliveryType === "express");
+  const expectedExpressMin = Math.min(
+    ...expressOrders.map((o) => o.totalAmount),
   );
-  const expectedExpressMin = Math.min(...expressOrders.map((o) => o.totalAmount));
-  const expectedExpressMax = Math.max(...expressOrders.map((o) => o.totalAmount));
+  const expectedExpressMax = Math.max(
+    ...expressOrders.map((o) => o.totalAmount),
+  );
   expect(expressGroup?.minAmount).to.equal(expectedExpressMin);
   expect(expressGroup?.maxAmount).to.equal(expectedExpressMax);
 
   const standardGroup = result.find((item) => item.deliveryType === "standard");
-  const standardOrders = testData.filter(
-    (o) => o.deliveryType === "standard",
-  );
+  const standardOrders = testData.filter((o) => o.deliveryType === "standard");
   const expectedStdMin = Math.min(...standardOrders.map((o) => o.totalAmount));
   const expectedStdMax = Math.max(...standardOrders.map((o) => o.totalAmount));
   expect(standardGroup?.minAmount).to.equal(expectedStdMin);

--- a/src/tests/group_operations.test.ts
+++ b/src/tests/group_operations.test.ts
@@ -47,6 +47,7 @@ describe("Group Operations", () => {
     GroupByPaymentStatusWithMultipleAggregations,
   );
   it("Group with Distinct in Callback", GroupWithDistinctInCallback);
+  it("Group with Min and Max", GroupWithMinAndMax);
   it("Cleanup", CleanupTest);
 });
 
@@ -305,6 +306,40 @@ async function GroupWithDistinctInCallback() {
   expect(standardGroup?.uniqueCustomers).to.have.lengthOf(
     expectedStandardCustomers.length,
   );
+}
+
+async function GroupWithMinAndMax() {
+  const result = await table
+    .group("deliveryType", (stream, group) => ({
+      deliveryType: group,
+      minAmount: stream.min("totalAmount"),
+      maxAmount: stream.max("totalAmount"),
+    }))
+    .run();
+
+  expect(result).to.be.an("array");
+  const expectedGroupCount = new Set(
+    testData.map((order) => order.deliveryType),
+  ).size;
+  expect(result).to.have.lengthOf(expectedGroupCount);
+
+  const expressGroup = result.find((item) => item.deliveryType === "express");
+  const expressOrders = testData.filter(
+    (o) => o.deliveryType === "express",
+  );
+  const expectedExpressMin = Math.min(...expressOrders.map((o) => o.totalAmount));
+  const expectedExpressMax = Math.max(...expressOrders.map((o) => o.totalAmount));
+  expect(expressGroup?.minAmount).to.equal(expectedExpressMin);
+  expect(expressGroup?.maxAmount).to.equal(expectedExpressMax);
+
+  const standardGroup = result.find((item) => item.deliveryType === "standard");
+  const standardOrders = testData.filter(
+    (o) => o.deliveryType === "standard",
+  );
+  const expectedStdMin = Math.min(...standardOrders.map((o) => o.totalAmount));
+  const expectedStdMax = Math.max(...standardOrders.map((o) => o.totalAmount));
+  expect(standardGroup?.minAmount).to.equal(expectedStdMin);
+  expect(standardGroup?.maxAmount).to.equal(expectedStdMax);
 }
 
 async function CleanupTest() {

--- a/src/tests/joins.test.ts
+++ b/src/tests/joins.test.ts
@@ -54,6 +54,7 @@ describe("Join Operations", () => {
   it("Left Join Orders with Users", LeftJoinOrdersWithUsers);
   it("Multiple Joins", MultipleJoins);
   it("Join with Filter", JoinWithFilter);
+  it("Join with Multi-Condition Predicate", JoinWithMultiConditionPredicate);
   it("Cleanup", CleanupTest);
 });
 
@@ -222,6 +223,31 @@ async function JoinWithFilter() {
       usersData.find((user) => user.email === order.customerEmail)?.isActive,
   ).length;
   expect(activeUsers).to.have.lengthOf(expectedActiveUsersCount);
+}
+
+async function JoinWithMultiConditionPredicate() {
+  const result = await ordersTable
+    .joinInner(
+      usersTable,
+      (left, right) =>
+        left.key("customerEmail").eq(right.key("email")).and(
+          right.key("isActive").eq(true),
+        ),
+      (left, right) => left.merge({ customer: right }),
+    )
+    .run();
+
+  expect(result).to.be.an("array");
+  const expected = ordersData.filter((order) => {
+    const user = usersData.find((u) => u.email === order.customerEmail);
+    return user && user.isActive;
+  });
+  expect(result).to.have.lengthOf(expected.length);
+
+  result.forEach((doc) => {
+    expect(doc.customer?.isActive).to.equal(true);
+    expect(doc.customerEmail).to.equal(doc.customer?.email);
+  });
 }
 
 async function CleanupTest() {

--- a/src/tests/joins.test.ts
+++ b/src/tests/joins.test.ts
@@ -241,7 +241,7 @@ async function JoinWithMultiConditionPredicate() {
   expect(result).to.be.an("array");
   const expected = ordersData.filter((order) => {
     const user = usersData.find((u) => u.email === order.customerEmail);
-    return user && user.isActive;
+    return user?.isActive;
   });
   expect(result).to.have.lengthOf(expected.length);
 

--- a/src/tests/joins.test.ts
+++ b/src/tests/joins.test.ts
@@ -230,9 +230,10 @@ async function JoinWithMultiConditionPredicate() {
     .joinInner(
       usersTable,
       (left, right) =>
-        left.key("customerEmail").eq(right.key("email")).and(
-          right.key("isActive").eq(true),
-        ),
+        left
+          .key("customerEmail")
+          .eq(right.key("email"))
+          .and(right.key("isActive").eq(true)),
       (left, right) => left.merge({ customer: right }),
     )
     .run();

--- a/src/tests/lookup_operations.test.ts
+++ b/src/tests/lookup_operations.test.ts
@@ -1,31 +1,46 @@
 import { Schema } from "@antelopejs/interface-database";
 import { expect } from "chai";
 import { getUniqueOrders, Order } from "./datasets/orders";
+import { getUniqueProducts, Product } from "./datasets/products";
 import { getUniqueUsers, User } from "./datasets/users";
+
+type OrderWithRefs = Order & { productIds?: string[] };
 
 const ordersTableName = "orders";
 const usersTableName = "users";
+const productsTableName = "products";
 
-const schema = new Schema<{ [ordersTableName]: Order; [usersTableName]: User }>(
-  "test-lookup-operations",
-  {
-    [ordersTableName]: Order,
-    [usersTableName]: User,
-  },
-);
+const ProductWithSkuIndex = {
+  ...Product,
+  indexes: { ...Product.indexes, sku: {} },
+};
+
+const schema = new Schema<{
+  [ordersTableName]: OrderWithRefs;
+  [usersTableName]: User;
+  [productsTableName]: Product;
+}>("test-lookup-operations", {
+  [ordersTableName]: Order,
+  [usersTableName]: User,
+  [productsTableName]: ProductWithSkuIndex,
+});
 
 const ordersTable = schema.instance("default").table(ordersTableName);
 const usersTable = schema.instance("default").table(usersTableName);
+const productsTable = schema.instance("default").table(productsTableName);
 
 const usersData = getUniqueUsers();
 const ordersData = getUniqueOrders();
+const productsData = getUniqueProducts();
 
 const insertedKeys: {
   users: string[];
   orders: string[];
+  products: string[];
 } = {
   users: [],
   orders: [],
+  products: [],
 };
 
 describe("Lookup Operations", () => {
@@ -33,11 +48,13 @@ describe("Lookup Operations", () => {
     await schema.createInstance("default").run();
     await ordersTable.delete().run();
     await usersTable.delete().run();
+    await productsTable.delete().run();
   });
 
   after(async () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();
+    await productsTable.delete().run();
     await schema.destroyInstance("default").run();
   });
 
@@ -45,18 +62,22 @@ describe("Lookup Operations", () => {
   it("Lookup Basic", LookupBasic);
   it("Lookup On Get", LookupOnGet);
   it("Lookup With Filter", LookupWithFilter);
+  it("Lookup with Subquery Inside Map", LookupWithSubqueryInsideMap);
   it("Cleanup", CleanupTest);
 });
 
 async function InsertTestData() {
   const usersResponse = await usersTable.insert(usersData).run();
   const ordersResponse = await ordersTable.insert(ordersData).run();
+  const productsResponse = await productsTable.insert(productsData).run();
 
   expect(usersResponse).to.be.an("array");
   expect(ordersResponse).to.be.an("array");
+  expect(productsResponse).to.be.an("array");
 
   insertedKeys.users = usersResponse;
   insertedKeys.orders = ordersResponse;
+  insertedKeys.products = productsResponse;
 }
 
 async function LookupBasic() {
@@ -118,11 +139,45 @@ async function LookupWithFilter() {
   });
 }
 
+async function LookupWithSubqueryInsideMap() {
+  const productIds = insertedKeys.products.slice(0, 2);
+  await ordersTable
+    .get(insertedKeys.orders[0])
+    .update({ productIds })
+    .run();
+
+  const result = await ordersTable
+    .get(insertedKeys.orders[0])
+    .do((order) =>
+      order.merge({
+        resolvedProducts: order
+          .key("productIds")
+          .map((pid) => productsTable.get(pid as any)),
+      }),
+    )
+    .run();
+
+  expect(result).to.be.an("object");
+  expect(result).to.have.property("resolvedProducts");
+  expect(result.resolvedProducts).to.be.an("array");
+  expect(result.resolvedProducts).to.have.lengthOf(productIds.length);
+
+  result.resolvedProducts.forEach((product) => {
+    expect(product).to.be.an("object");
+    expect(product).to.have.property("name");
+    expect(product).to.have.property("price");
+    expect(product).to.have.property("sku");
+  });
+}
+
 async function CleanupTest() {
   for (const key of insertedKeys.orders) {
     await ordersTable.get(key).delete().run();
   }
   for (const key of insertedKeys.users) {
     await usersTable.get(key).delete().run();
+  }
+  for (const key of insertedKeys.products) {
+    await productsTable.get(key).delete().run();
   }
 }

--- a/src/tests/lookup_operations.test.ts
+++ b/src/tests/lookup_operations.test.ts
@@ -142,10 +142,7 @@ async function LookupWithFilter() {
 
 async function LookupWithSubqueryInsideMap() {
   const productIds = insertedKeys.products.slice(0, 2);
-  await ordersTable
-    .get(insertedKeys.orders[0])
-    .update({ productIds })
-    .run();
+  await ordersTable.get(insertedKeys.orders[0]).update({ productIds }).run();
 
   const result = await ordersTable
     .get(insertedKeys.orders[0])
@@ -182,10 +179,10 @@ async function ChainedLookup() {
 
   const antoineOrder = result.find((doc) => doc.orderId === "ORD-001");
   expect(antoineOrder).to.not.equal(undefined);
-  expect(antoineOrder!.customerName).to.be.an("object");
-  expect(antoineOrder!.customerName).to.have.property("name", "Antoine");
-  expect(antoineOrder!.productSku).to.be.an("object");
-  expect(antoineOrder!.productSku).to.have.property("sku", "LAPTOP-001");
+  expect(antoineOrder?.customerName).to.be.an("object");
+  expect(antoineOrder?.customerName).to.have.property("name", "Antoine");
+  expect(antoineOrder?.productSku).to.be.an("object");
+  expect(antoineOrder?.productSku).to.have.property("sku", "LAPTOP-001");
 }
 
 async function CleanupTest() {

--- a/src/tests/lookup_operations.test.ts
+++ b/src/tests/lookup_operations.test.ts
@@ -166,6 +166,11 @@ async function LookupWithSubqueryInsideMap() {
     expect(product).to.have.property("price");
     expect(product).to.have.property("sku");
   });
+
+  await ordersTable
+    .get(insertedKeys.orders[0])
+    .update({ productIds: undefined } as any)
+    .run();
 }
 
 async function ChainedLookup() {

--- a/src/tests/lookup_operations.test.ts
+++ b/src/tests/lookup_operations.test.ts
@@ -63,6 +63,7 @@ describe("Lookup Operations", () => {
   it("Lookup On Get", LookupOnGet);
   it("Lookup With Filter", LookupWithFilter);
   it("Lookup with Subquery Inside Map", LookupWithSubqueryInsideMap);
+  it("Chained Lookup", ChainedLookup);
   it("Cleanup", CleanupTest);
 });
 
@@ -168,6 +169,23 @@ async function LookupWithSubqueryInsideMap() {
     expect(product).to.have.property("price");
     expect(product).to.have.property("sku");
   });
+}
+
+async function ChainedLookup() {
+  const result = await ordersTable
+    .lookup(usersTable, "customerName", "name")
+    .lookup(productsTable, "productSku", "sku")
+    .run();
+
+  expect(result).to.be.an("array");
+  expect(result).to.have.lengthOf(ordersData.length);
+
+  const antoineOrder = result.find((doc) => doc.orderId === "ORD-001");
+  expect(antoineOrder).to.not.equal(undefined);
+  expect(antoineOrder!.customerName).to.be.an("object");
+  expect(antoineOrder!.customerName).to.have.property("name", "Antoine");
+  expect(antoineOrder!.productSku).to.be.an("object");
+  expect(antoineOrder!.productSku).to.have.property("sku", "LAPTOP-001");
 }
 
 async function CleanupTest() {

--- a/src/tests/row_level_operations.test.ts
+++ b/src/tests/row_level_operations.test.ts
@@ -362,7 +362,7 @@ async function UpdateWithExpressionNumeric() {
   // Increment price by 100 using expression-based update
   const modified = await t1Vehicles
     .filter((doc) => doc.key("car").eq("Peugeot"))
-    .update((doc: any) => ({ price: doc.key("price").add(100) }))
+    .update(((doc) => ({ price: doc.key("price").add(100) } as any)))
     .run();
 
   const peugeotCount = vehicles.filter((v) => v.car === "Peugeot").length;
@@ -380,7 +380,7 @@ async function UpdateWithExpressionOnSingleSelection() {
   // Test expression-based update on SingleSelection (via .get())
   const modified = await t1Vehicles
     .get(vehicleKeys[0])
-    .update((doc: any) => ({ kilometers: doc.key("kilometers").mul(2) }))
+    .update(((doc) => ({ kilometers: doc.key("kilometers").mul(2) } as any)))
     .run();
 
   expect(modified).to.equal(1);
@@ -398,10 +398,10 @@ async function UpdateWithExpressionMixed() {
   // Mix plain values and expressions
   const modified = await t1Vehicles
     .filter((doc) => doc.key("car").eq("Peugeot"))
-    .update((doc: any) => ({
+    .update(((doc) => ({
       price: doc.key("price").add(500),
       isElectric: true,
-    }))
+    } as any)))
     .run();
 
   const peugeotCount = vehicles.filter((v) => v.car === "Peugeot").length;

--- a/src/tests/row_level_operations.test.ts
+++ b/src/tests/row_level_operations.test.ts
@@ -362,7 +362,7 @@ async function UpdateWithExpressionNumeric() {
   // Increment price by 100 using expression-based update
   const modified = await t1Vehicles
     .filter((doc) => doc.key("car").eq("Peugeot"))
-    .update(((doc) => ({ price: doc.key("price").add(100) } as any)))
+    .update((doc) => ({ price: doc.key("price").add(100) }) as any)
     .run();
 
   const peugeotCount = vehicles.filter((v) => v.car === "Peugeot").length;
@@ -380,7 +380,7 @@ async function UpdateWithExpressionOnSingleSelection() {
   // Test expression-based update on SingleSelection (via .get())
   const modified = await t1Vehicles
     .get(vehicleKeys[0])
-    .update(((doc) => ({ kilometers: doc.key("kilometers").mul(2) } as any)))
+    .update((doc) => ({ kilometers: doc.key("kilometers").mul(2) }) as any)
     .run();
 
   expect(modified).to.equal(1);
@@ -398,10 +398,13 @@ async function UpdateWithExpressionMixed() {
   // Mix plain values and expressions
   const modified = await t1Vehicles
     .filter((doc) => doc.key("car").eq("Peugeot"))
-    .update(((doc) => ({
-      price: doc.key("price").add(500),
-      isElectric: true,
-    } as any)))
+    .update(
+      (doc) =>
+        ({
+          price: doc.key("price").add(500),
+          isElectric: true,
+        }) as any,
+    )
     .run();
 
   const peugeotCount = vehicles.filter((v) => v.car === "Peugeot").length;


### PR DESCRIPTION
## Summary
- Add regression tests for mongodb 1.0.5 fixes (subquery in .do(), null returns, temporary field cleanup, distinct in group, subquery in .map())
- Add comprehensive coverage for untested ValueProxy operators (ge, le, and, or, not, sub, div, mod, ceil, floor, bitwise, downcase, strlen, match, concat, array index/slice/isempty, object keys/values/hasfields)
- Add date extraction tests (dayofweek, dayofyear, hours, minutes, seconds, timeofday)
- Add between with dates, datum pluck, chained lookups, multi-condition joins, group min/max, bulk change feed events
- Add dynamic ValueProxy key access test
- Add getAll tests with 3+ keys
- Update mongodb-memory-server-core to v11
- Update test mongodb version to 1.0.5
- Fix type annotations across existing tests

## Test plan
- All 202 tests pass with AntelopeJS/mongodb#15

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive test coverage (202 tests total) to the AntelopeJS interface-database package. It introduces regression tests for MongoDB 1.0.5 fixes (subquery in `.do()`, null returns, temporary field cleanup, distinct in group, subquery in `.map()`), extends coverage of previously untested `ValueProxy` operators (bitwise, string, array, object), and adds new test scenarios for date extraction, chained lookups, multi-condition joins, group min/max, and bulk change feed events.

**Key changes:**
- Bumps `mongodb-memory-server-core` from `^10.4.3` → `^11.0.1` and target MongoDB adapter from `1.0.0` → `1.0.5`
- Adds `products` table / dataset to `lookup_operations.test.ts` and `joins.test.ts` to support chained-lookup and join regression tests
- Introduces `VehicleWithDateIndex` / `ProductWithSkuIndex` inline schema variants in `between_operations.test.ts` and `lookup_operations.test.ts` to enable index-backed queries without touching the shared schema constants
- All new helper functions follow the existing module-level `async function` pattern; test ordering is consistent with surrounding describe blocks
- Type-annotation improvements in `row_level_operations.test.ts` move the `as any` cast to the return value rather than the parameter, which is strictly better TypeScript

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is purely additive test coverage with no changes to production code.

All 14 changed files are test files or dependency updates. No production source code is modified. The new tests are logically consistent with the in-memory test data, follow established patterns, and the PR author reports all 202 tests pass against mongodb 1.0.5. No P0 or P1 issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tests/do_operations.test.ts | Adds 9 new test cases for ValueProxy arithmetic (sub, div, mod, ceil/floor), bitwise operators, array ops (index, slice, count), object keys/values, dynamic key access, and mongodb 1.0.5 regression tests (subquery field reference, null return, no temporary fields). |
| src/tests/filters.test.ts | Adds 13 new filter tests covering ge, le, and, or, not, downcase, strlen, match, concat, array isempty/index, and object hasfields/keys operators; all assertions are consistent with the in-memory testData expectations. |
| src/tests/lookup_operations.test.ts | Adds a products table/schema and two new tests: LookupWithSubqueryInsideMap (regression for subquery inside map) with post-test cleanup, and ChainedLookup (two sequential lookups). Addressed prior review comment by adding a cleanup call after the mutation. |
| src/tests/change_feeds.test.ts | Adds BulkInsertEventTest verifying that two simultaneously inserted documents each produce an added change event; follows existing timing/race pattern with 200 ms settle windows. |
| src/tests/date_operations.test.ts | Adds four date extraction tests (dayofweek, dayofyear, hours/minutes/seconds, timeofday) with correct range assertions (1-7, 1-366, 0-23/59/59, 0-86399). |
| src/tests/group_operations.test.ts | Adds GroupWithDistinctInCallback and GroupWithMinAndMax tests; expected values are computed directly from testData, making assertions deterministic. |
| src/tests/joins.test.ts | Adds JoinWithMultiConditionPredicate test combining an equality predicate with an isActive boolean filter using .and(); expected count derived correctly from in-memory data. |
| src/tests/between_operations.test.ts | Adds BetweenWithDateField test using manufactured date range; correctly adds manufactured index via VehicleWithDateIndex and uses inclusive-low/exclusive-high semantics consistent with the rest of the between test suite. |
| src/tests/basic_operations.test.ts | Adds GetAllManyPrimaryKeys and GetAllManyIndexValues tests for 3-key getAll queries; uses updated expectedVehicles state correctly relative to the test execution order. |
| src/tests/row_level_operations.test.ts | Type annotation cleanup only: moves as any cast from the callback parameter to the return value, which is the correct TypeScript pattern. |
| src/tests/aggregation_operations.test.ts | Adds PluckOnSingleSelection test and improves CursorTest type annotation from any[] to Vehicle[]. |
| package.json | Bumps mongodb-memory-server-core from ^10 to ^11; matched by pnpm-lock.yaml update. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test Suite] --> B[basic_operations]
    A --> C[between_operations]
    A --> D[aggregation_operations]
    A --> E[filters]
    A --> F[do_operations]
    A --> G[date_operations]
    A --> H[group_operations]
    A --> I[joins]
    A --> J[lookup_operations]
    A --> K[change_feeds]
    A --> L[row_level_operations]

    B --> B1[GetAll 3+ primary keys NEW]
    B --> B2[GetAll 3+ index values NEW]
    C --> C1[Between with Date Field NEW]
    D --> D1[Pluck on Single Selection NEW]
    E --> E1[ge / le NEW]
    E --> E2[and / or / not NEW]
    E --> E3[downcase / strlen / match / concat NEW]
    E --> E4[Array isempty / index NEW]
    E --> E5[Object hasfields / keys NEW]
    F --> F1[Subquery Field Reference NEW]
    F --> F2[Null Return Regression NEW]
    F --> F3[No Temporary Lookup Fields NEW]
    F --> F4[sub / div / mod / ceil / floor NEW]
    F --> F5[Bitwise band/bor/bxor/bnot/shift NEW]
    F --> F6[Array index / slice / count NEW]
    F --> F7[Object keys / values NEW]
    F --> F8[Dynamic Key Access NEW]
    G --> G1[dayofweek / dayofyear NEW]
    G --> G2[hours / minutes / seconds NEW]
    G --> G3[timeofday NEW]
    H --> H1[Distinct in Callback NEW]
    H --> H2[Min and Max NEW]
    I --> I1[Multi-Condition Predicate NEW]
    J --> J1[Subquery Inside Map NEW]
    J --> J2[Chained Lookup NEW]
    K --> K1[Bulk Insert Events NEW]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tests/basic_operations.test.ts`, line 219-248 ([link](https://github.com/antelopejs/interface-database/blob/870a0bf5396220a179af4e6caf5bb10234bdfd06/src/tests/basic_operations.test.ts#L219-L248)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`GetAllManyIndexValues` — fragile expected-count calculation**

   ```ts
   const expectedCount = expectedVehicles.filter((v) =>
     targetPrices.includes(v.price),
   ).length;
   ```

   If any two of the first three vehicles share the same price, `targetPrices` will contain a duplicate value, but `expectedVehicles.filter(...)` would still count both documents as matches. Depending on whether the database de-duplicates keys passed to `getAll`, the actual result count may differ from the computed `expectedCount`. It would be cleaner to use a unique field (e.g., `car`) to avoid this ambiguity, or to assert a minimum count (`gte`) rather than an exact length.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/tests/basic_operations.test.ts
   Line: 219-248

   Comment:
   **`GetAllManyIndexValues` — fragile expected-count calculation**

   ```ts
   const expectedCount = expectedVehicles.filter((v) =>
     targetPrices.includes(v.price),
   ).length;
   ```

   If any two of the first three vehicles share the same price, `targetPrices` will contain a duplicate value, but `expectedVehicles.filter(...)` would still count both documents as matches. Depending on whether the database de-duplicates keys passed to `getAll`, the actual result count may differ from the computed `expectedCount`. It would be cleaner to use a unique field (e.g., `car`) to avoid this ambiguity, or to assert a minimum count (`gte`) rather than an exact length.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["style: fix remaining lint issues"](https://github.com/antelopejs/interface-database/commit/a218db4f763c24d66f1a6ddcca9da09fb5a6d0e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27171992)</sub>

<!-- /greptile_comment -->