### PR TITLE
feat!: per-table tenantScoped + CROSS_TENANT + physicalStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,34 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./common": {
+      "types": "./dist/common.d.ts",
+      "default": "./dist/common.js"
+    },
+    "./datum": {
+      "types": "./dist/datum.d.ts",
+      "default": "./dist/datum.js"
+    },
+    "./query": {
+      "types": "./dist/query.d.ts",
+      "default": "./dist/query.js"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "default": "./dist/schema.js"
+    },
+    "./selection": {
+      "types": "./dist/selection.d.ts",
+      "default": "./dist/selection.js"
+    },
+    "./stream": {
+      "types": "./dist/stream.d.ts",
+      "default": "./dist/stream.js"
+    },
+    "./valueproxy": {
+      "types": "./dist/valueproxy.d.ts",
+      "default": "./dist/valueproxy.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/mongodb",
-        version: "1.0.7",
+        version: "1.1.0",
       },
     },
   },

--- a/src/antelope.test.ts
+++ b/src/antelope.test.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/mongodb",
-        version: "1.0.5",
+        version: "1.0.7",
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 export { Datum } from "./datum";
 export { Query } from "./query";
 export {
+  CROSS_TENANT,
   Schema,
   SchemaDefinition,
   SchemaInstance,
   SchemaOptions,
+  TenantId,
 } from "./schema";
 export { Selection, SingleSelection, Table } from "./selection";
 export { Stream } from "./stream";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,5 @@
 import { RegisteringProxy } from "@antelopejs/interface-core";
 import { QueryStage, StagedObject } from "./common";
-import { Query } from "./query";
 import { Table } from "./selection";
 
 /**
@@ -36,6 +35,18 @@ export interface TableDefinition {
    * List of secondary indexes
    */
   indexes: Record<string, IndexDefinition>;
+
+  /**
+   * When true, every row in this table carries a `tenant_id` field and
+   * queries on the table must be performed via a tenant-bound instance
+   * (see `Schema.instance(id)`). Implementations should:
+   *
+   * - inject the tenant filter on read/update/delete
+   * - stamp `tenant_id` on insert
+   * - reject queries with no tenant context
+   * - skip the filter when the tenant is `CROSS_TENANT` (read/update/delete only)
+   */
+  tenantScoped?: boolean;
 }
 
 /**
@@ -46,8 +57,30 @@ export interface SchemaDefinition {
 }
 
 export interface SchemaOptions {
-  rowLevel?: boolean;
+  /**
+   * Name of the physical database that backs this schema.
+   *
+   * Multiple schemas can share the same `physicalStore` to live in the same
+   * physical database, enabling native cross-schema joins. Defaults to the
+   * schema id when omitted.
+   */
+  physicalStore?: string;
 }
+
+/**
+ * Sentinel value used as a tenant identifier to opt into a cross-tenant query
+ * on a tenant-scoped table.
+ *
+ * Implementations should skip the tenant filter when this value is provided
+ * on read/update/delete, and reject it on insert (cross-tenant insert is
+ * meaningless).
+ *
+ * Symbols are not JSON-serializable and cannot be forged from network input,
+ * which makes this a safe escape hatch for admin/system-level operations.
+ */
+export const CROSS_TENANT: unique symbol = Symbol("antelopejs:cross-tenant");
+
+export type TenantId = string | typeof CROSS_TENANT;
 
 //@internal
 export const Schemas = new RegisteringProxy<
@@ -57,9 +90,8 @@ export const Schemas = new RegisteringProxy<
 /**
  * A schema determines the structure of a database
  *
- * Each schema can have multiple instances
- *
- * The internal organization of these instances is left up to the module implementation
+ * Each schema can be queried with an optional tenant context via `instance()`.
+ * The physical realization is controlled by `SchemaOptions.physicalStore`.
  */
 export class Schema<T = any> extends StagedObject {
   private static readonly registry = new Map<string, Schema>();
@@ -91,32 +123,17 @@ export class Schema<T = any> extends StagedObject {
   }
 
   /**
-   * Gets a specific instance of the schema
+   * Gets a query context bound to an optional tenant.
    *
-   * @param id Instance ID
-   * @returns Schema instance
+   * - `undefined` → no tenant context. Tenant-scoped tables will reject the query.
+   * - `string` → tenant id. Tenant-scoped tables filter on it; non-tenant tables ignore it.
+   * - `CROSS_TENANT` → admin escape hatch. Tenant-scoped tables skip the filter on
+   *   read/update/delete, reject on insert.
+   *
+   * @param id Tenant identifier or sentinel
    */
-  public instance(id?: string) {
+  public instance(id?: TenantId) {
     return this.stage(SchemaInstance<T>, "instance", { id });
-  }
-
-  /**
-   * Creates a new instance of the schema
-   *
-   * @param id Instance ID
-   * @returns Created instance ID
-   */
-  public createInstance(id?: string) {
-    return this.stage(Query<string>, "createInstance", { id });
-  }
-
-  /**
-   * Destroys an existing instance of the schema
-   *
-   * @param id Instance ID
-   */
-  public destroyInstance(id?: string) {
-    return this.stage(Query<void>, "destroyInstance", { id });
   }
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -77,9 +77,25 @@ export interface SchemaOptions {
  *
  * Symbols are not JSON-serializable and cannot be forged from network input,
  * which makes this a safe escape hatch for admin/system-level operations.
+ *
+ * **Implementation contract**:
+ * - Compare the tenant id by identity (`id === CROSS_TENANT`), never by any
+ *   string check — symbols carry no string representation.
+ * - The query stage pipeline carrying `CROSS_TENANT` MUST stay in-process.
+ *   Any transport, queue, IPC, or logging layer that round-trips
+ *   `QueryStage.options` through `JSON.stringify` will silently drop the
+ *   symbol and `id` will become `undefined`, which on a tenant-scoped table
+ *   then throws ("tenant required") instead of bypassing the filter. Run the
+ *   pipeline against the adapter directly — do not serialize.
  */
 export const CROSS_TENANT: unique symbol = Symbol("antelopejs:cross-tenant");
 
+/**
+ * Tenant identifier accepted by `Schema.instance()`.
+ *
+ * See {@link CROSS_TENANT} for the implementation contract around the
+ * cross-tenant sentinel — notably that it cannot survive JSON serialization.
+ */
 export type TenantId = string | typeof CROSS_TENANT;
 
 //@internal

--- a/src/tests/aggregation_operations.test.ts
+++ b/src/tests/aggregation_operations.test.ts
@@ -13,13 +13,11 @@ let insertedKeys: string[] = [];
 
 describe("Aggregation & Projection Operations", () => {
   before(async () => {
-    await schema.createInstance("default").run();
     await table.delete().run();
   });
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/basic_operations.test.ts
+++ b/src/tests/basic_operations.test.ts
@@ -27,13 +27,10 @@ describe("Basic Operations", () => {
   it("Replace", ReplaceTest);
   it("Delete", DeleteTest);
 
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 });
 

--- a/src/tests/basic_operations.test.ts
+++ b/src/tests/basic_operations.test.ts
@@ -27,8 +27,6 @@ describe("Basic Operations", () => {
   it("Replace", ReplaceTest);
   it("Delete", DeleteTest);
 
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/between_operations.test.ts
+++ b/src/tests/between_operations.test.ts
@@ -18,13 +18,11 @@ let insertedKeys: string[] = [];
 
 describe("Between Operations", () => {
   before(async () => {
-    await schema.createInstance("default").run();
     await table.delete().run();
   });
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/change_feeds.test.ts
+++ b/src/tests/change_feeds.test.ts
@@ -14,13 +14,10 @@ describe("Change Streams", () => {
   it("Update Event", UpdateEventTest);
   it("Delete Event", DeleteEventTest);
   it("Bulk Insert Events", BulkInsertEventTest);
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 });
 

--- a/src/tests/change_feeds.test.ts
+++ b/src/tests/change_feeds.test.ts
@@ -14,8 +14,6 @@ describe("Change Streams", () => {
   it("Update Event", UpdateEventTest);
   it("Delete Event", DeleteEventTest);
   it("Bulk Insert Events", BulkInsertEventTest);
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/date_operations.test.ts
+++ b/src/tests/date_operations.test.ts
@@ -13,8 +13,6 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Date Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/date_operations.test.ts
+++ b/src/tests/date_operations.test.ts
@@ -13,13 +13,10 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Date Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -14,8 +14,6 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Do Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/do_operations.test.ts
+++ b/src/tests/do_operations.test.ts
@@ -14,13 +14,10 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Do Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/filters.test.ts
+++ b/src/tests/filters.test.ts
@@ -14,13 +14,10 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Filter Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/filters.test.ts
+++ b/src/tests/filters.test.ts
@@ -14,8 +14,6 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Filter Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/group_operations.test.ts
+++ b/src/tests/group_operations.test.ts
@@ -15,13 +15,11 @@ let insertedKeys: string[] = [];
 
 describe("Group Operations", () => {
   before(async () => {
-    await schema.createInstance("default").run();
     await table.delete().run();
   });
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/instance_modes.test.ts
+++ b/src/tests/instance_modes.test.ts
@@ -64,11 +64,11 @@ describe("Tenant-Scoped Tables", () => {
   it("Tenant isolation", TenantIsolation);
   it("Cross-tenant query via CROSS_TENANT sees all", TenantCrossSeesAll);
   it("Cross-tenant insert throws", TenantCrossInsertThrows);
+  it("Cross-tenant update touches every tenant", TenantCrossUpdate);
+  it("Cross-tenant delete wipes every tenant", TenantCrossDelete);
 
   after(async () => {
-    await tenantSchema.instance("t1").table(tableName).delete().run();
-    await tenantSchema.instance("t2").table(tableName).delete().run();
-    await tenantSchema.instance("cleanup").table(tableName).delete().run();
+    await tenantSchema.instance(CROSS_TENANT).table(tableName).delete().run();
   });
 });
 
@@ -127,4 +127,34 @@ async function TenantCrossInsertThrows() {
     threw = true;
   }
   expect(threw).to.equal(true);
+}
+
+async function TenantCrossUpdate() {
+  const crossTable = tenantSchema.instance(CROSS_TENANT).table(tableName);
+  const before = await crossTable.run();
+  expect(before.length).to.be.greaterThanOrEqual(2);
+
+  const sentinel = 424242;
+  await crossTable.update({ price: sentinel }).run();
+
+  const t1Docs = await tenantSchema.instance("t1").table(tableName).run();
+  const t2Docs = await tenantSchema.instance("t2").table(tableName).run();
+  expect(t1Docs.length).to.be.greaterThan(0);
+  expect(t2Docs.length).to.be.greaterThan(0);
+  for (const doc of [...t1Docs, ...t2Docs]) {
+    expect(doc.price).to.equal(sentinel);
+  }
+}
+
+async function TenantCrossDelete() {
+  const crossTable = tenantSchema.instance(CROSS_TENANT).table(tableName);
+  await crossTable.delete().run();
+
+  const remaining = await crossTable.run();
+  expect(remaining).to.have.lengthOf(0);
+
+  const t1Docs = await tenantSchema.instance("t1").table(tableName).run();
+  const t2Docs = await tenantSchema.instance("t2").table(tableName).run();
+  expect(t1Docs).to.have.lengthOf(0);
+  expect(t2Docs).to.have.lengthOf(0);
 }

--- a/src/tests/instance_modes.test.ts
+++ b/src/tests/instance_modes.test.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@antelopejs/interface-database";
+import { CROSS_TENANT, Schema } from "@antelopejs/interface-database";
 import { expect } from "chai";
 import { Vehicle } from "./datasets/vehicles";
 
@@ -14,89 +14,23 @@ function vehicle(car: string, price: number): Vehicle {
   };
 }
 
-const dbLevelSchema = new Schema<{ [tableName]: Vehicle }>("test-db-level", {
+const globalSchema = new Schema<{ [tableName]: Vehicle }>("test-im-global", {
   [tableName]: Vehicle,
 });
-const globalSchema = new Schema<{ [tableName]: Vehicle }>("test-global", {
-  [tableName]: Vehicle,
-});
-const rowLevelSchema = new Schema<{ [tableName]: Vehicle }>(
-  "test-row-level",
-  { [tableName]: Vehicle },
-  { rowLevel: true },
-);
-
-describe("Database-Level Instances", () => {
-  it("createInstance / destroyInstance", CreateAndDestroyInstance);
-  it("Named instance CRUD", NamedInstanceCrud);
-  it("Instance isolation", InstanceIsolation);
-
-  after(async () => {
-    await dbLevelSchema.instance("a").table(tableName).delete().run();
-    await dbLevelSchema.instance("b").table(tableName).delete().run();
-    await dbLevelSchema.destroyInstance("a").run();
-    await dbLevelSchema.destroyInstance("b").run();
-    await dbLevelSchema.destroyInstance("named").run();
-  });
+const tenantSchema = new Schema<{ [tableName]: Vehicle }>("test-im-tenant", {
+  [tableName]: { ...Vehicle, tenantScoped: true },
 });
 
-async function CreateAndDestroyInstance() {
-  const id = await dbLevelSchema.createInstance("inst1").run();
-  expect(id).to.equal("inst1");
-  await dbLevelSchema.destroyInstance("inst1").run();
-}
-
-async function NamedInstanceCrud() {
-  await dbLevelSchema.createInstance("named").run();
-  const table = dbLevelSchema.instance("named").table(tableName);
-
-  const keys = await table.insert([vehicle("Peugeot", 3000)]).run();
-  expect(keys).to.have.lengthOf(1);
-
-  const doc = await table.get(keys[0]).run();
-  expect(doc).to.have.property("car", "Peugeot");
-
-  const updated = await table.get(keys[0]).update({ price: 9999 }).run();
-  expect(updated).to.equal(1);
-
-  const deleted = await table.get(keys[0]).delete().run();
-  expect(deleted).to.equal(1);
-
-  const gone = await table.get(keys[0]).run();
-  expect(gone).to.equal(undefined);
-}
-
-async function InstanceIsolation() {
-  await dbLevelSchema.createInstance("a").run();
-  await dbLevelSchema.createInstance("b").run();
-  const tableA = dbLevelSchema.instance("a").table(tableName);
-  const tableB = dbLevelSchema.instance("b").table(tableName);
-
-  await tableA.insert([vehicle("Peugeot", 3000)]).run();
-
-  const allB = await tableB.run();
-  expect(allB).to.be.an("array").with.lengthOf(0);
-}
-
-describe("Global Instance", () => {
-  it("createInstance(undefined) returns undefined", GlobalCreateInstance);
-  it("CRUD on global instance", GlobalInstanceCrud);
-  it("Global instance isolation from named", GlobalNamedIsolation);
+describe("Global Tables", () => {
+  it("CRUD without tenant context", GlobalCrud);
+  it("Tenant id is ignored on global tables", GlobalIgnoresTenant);
 
   after(async () => {
     await globalSchema.instance().table(tableName).delete().run();
-    await globalSchema.instance("named").table(tableName).delete().run();
-    await globalSchema.destroyInstance(undefined).run();
-    await globalSchema.destroyInstance("named").run();
   });
 });
 
-async function GlobalCreateInstance() {
-  const id = await globalSchema.createInstance(undefined).run();
-  expect(id).to.equal(undefined);
-}
-
-async function GlobalInstanceCrud() {
+async function GlobalCrud() {
   const table = globalSchema.instance().table(tableName);
 
   const keys = await table.insert([vehicle("Renault", 5000)]).run();
@@ -115,60 +49,41 @@ async function GlobalInstanceCrud() {
   expect(gone).to.equal(undefined);
 }
 
-async function GlobalNamedIsolation() {
-  await globalSchema.createInstance("named").run();
-  const globalTable = globalSchema.instance().table(tableName);
-  const namedTable = globalSchema.instance("named").table(tableName);
+async function GlobalIgnoresTenant() {
+  const tableNoTenant = globalSchema.instance().table(tableName);
+  const tableWithTenant = globalSchema.instance("anything").table(tableName);
 
-  await globalTable.insert([vehicle("Peugeot", 3000)]).run();
-
-  const namedDocs = await namedTable.run();
-  expect(namedDocs).to.be.an("array").with.lengthOf(0);
-
-  await namedTable.insert([vehicle("Citroen", 4000)]).run();
-
-  const globalDocs = await globalTable.run();
-  expect(globalDocs).to.be.an("array").with.lengthOf(1);
+  await tableNoTenant.insert([vehicle("Citroen", 4000)]).run();
+  const seen = await tableWithTenant.run();
+  expect(seen).to.have.length.greaterThan(0);
 }
 
-describe("Row-Level Tenancy", () => {
-  it("instance(undefined) throws", RowLevelUndefinedThrows);
-  it("createInstance is no-op", RowLevelCreateInstance);
-  it("destroyInstance is no-op", RowLevelDestroyInstance);
-  it("Insert stamps tenant_id", RowLevelInsertStamps);
-  it("Tenant isolation", RowLevelTenantIsolation);
-  it("Cross-tenant count", RowLevelCrossCount);
-  it("Update scoped to tenant", RowLevelScopedUpdate);
-  it("Delete scoped to tenant", RowLevelScopedDelete);
+describe("Tenant-Scoped Tables", () => {
+  it("instance(undefined) throws", TenantUndefinedThrows);
+  it("Insert stamps tenant_id", TenantInsertStamps);
+  it("Tenant isolation", TenantIsolation);
+  it("Cross-tenant query via CROSS_TENANT sees all", TenantCrossSeesAll);
+  it("Cross-tenant insert throws", TenantCrossInsertThrows);
 
   after(async () => {
-    await rowLevelSchema.instance("t1").table(tableName).delete().run();
-    await rowLevelSchema.instance("t2").table(tableName).delete().run();
-    await rowLevelSchema.instance("cleanup").table(tableName).delete().run();
+    await tenantSchema.instance("t1").table(tableName).delete().run();
+    await tenantSchema.instance("t2").table(tableName).delete().run();
+    await tenantSchema.instance("cleanup").table(tableName).delete().run();
   });
 });
 
-async function RowLevelUndefinedThrows() {
+async function TenantUndefinedThrows() {
   let threw = false;
   try {
-    await rowLevelSchema.instance().table(tableName).count().run();
+    await tenantSchema.instance().table(tableName).count().run();
   } catch {
     threw = true;
   }
   expect(threw).to.equal(true);
 }
 
-async function RowLevelCreateInstance() {
-  const id = await rowLevelSchema.createInstance("t1").run();
-  expect(id).to.equal("t1");
-}
-
-async function RowLevelDestroyInstance() {
-  await rowLevelSchema.destroyInstance("t1").run();
-}
-
-async function RowLevelInsertStamps() {
-  const table = rowLevelSchema.instance("cleanup").table(tableName);
+async function TenantInsertStamps() {
+  const table = tenantSchema.instance("cleanup").table(tableName);
   const keys = await table.insert([vehicle("Peugeot", 3000)]).run();
   expect(keys).to.have.lengthOf(1);
 
@@ -176,9 +91,9 @@ async function RowLevelInsertStamps() {
   expect(doc).to.have.property("tenant_id", "cleanup");
 }
 
-async function RowLevelTenantIsolation() {
-  const t1Table = rowLevelSchema.instance("t1").table(tableName);
-  const t2Table = rowLevelSchema.instance("t2").table(tableName);
+async function TenantIsolation() {
+  const t1Table = tenantSchema.instance("t1").table(tableName);
+  const t2Table = tenantSchema.instance("t2").table(tableName);
 
   await t1Table.insert([vehicle("Peugeot", 3000)]).run();
   await t2Table.insert([vehicle("Renault", 5000)]).run();
@@ -191,54 +106,25 @@ async function RowLevelTenantIsolation() {
   expect(t2Docs[0].car).to.equal("Renault");
 }
 
-async function RowLevelCrossCount() {
-  const t1Table = rowLevelSchema.instance("t1").table(tableName);
-  const t2Table = rowLevelSchema.instance("t2").table(tableName);
-
-  await t1Table
-    .insert([vehicle("Citroen", 4000), vehicle("Tesla", 50000)])
-    .run();
-
-  const t1Docs = await t1Table.run();
-  const t2Docs = await t2Table.run();
-  expect(t1Docs).to.have.lengthOf(3);
-  expect(t2Docs).to.have.lengthOf(1);
+async function TenantCrossSeesAll() {
+  const crossTable = tenantSchema.instance(CROSS_TENANT).table(tableName);
+  const all = await crossTable.run();
+  expect(all.length).to.be.greaterThanOrEqual(2);
+  const cars = all.map((doc) => doc.car);
+  expect(cars).to.include("Peugeot");
+  expect(cars).to.include("Renault");
 }
 
-async function RowLevelScopedUpdate() {
-  const t1Table = rowLevelSchema.instance("t1").table(tableName);
-  const t2Table = rowLevelSchema.instance("t2").table(tableName);
-
-  const t2Before = await t2Table.run();
-  const t2PriceBefore = t2Before[0].price;
-
-  await t1Table
-    .filter((doc) => doc.key("car").eq("Peugeot"))
-    .update({ price: 1 })
-    .run();
-
-  const t2After = await t2Table.run();
-  expect(t2After[0].price).to.equal(t2PriceBefore);
-
-  const t1Updated = await t1Table
-    .filter((doc) => doc.key("car").eq("Peugeot"))
-    .run();
-  for (const doc of t1Updated) {
-    expect(doc.price).to.equal(1);
+async function TenantCrossInsertThrows() {
+  let threw = false;
+  try {
+    await tenantSchema
+      .instance(CROSS_TENANT)
+      .table(tableName)
+      .insert([vehicle("Forbidden", 0)])
+      .run();
+  } catch {
+    threw = true;
   }
-}
-
-async function RowLevelScopedDelete() {
-  const t1Table = rowLevelSchema.instance("t1").table(tableName);
-  const t2Table = rowLevelSchema.instance("t2").table(tableName);
-
-  const t2CountBefore = await t2Table.run();
-
-  await t1Table.delete().run();
-
-  const t1Remaining = await t1Table.run();
-  expect(t1Remaining).to.have.lengthOf(0);
-
-  const t2CountAfter = await t2Table.run();
-  expect(t2CountAfter).to.have.lengthOf(t2CountBefore.length);
+  expect(threw).to.equal(true);
 }

--- a/src/tests/joins.test.ts
+++ b/src/tests/joins.test.ts
@@ -37,8 +37,6 @@ const insertedKeys: {
 };
 
 describe("Join Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();

--- a/src/tests/joins.test.ts
+++ b/src/tests/joins.test.ts
@@ -37,15 +37,12 @@ const insertedKeys: {
 };
 
 describe("Join Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();
     await productsTable.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/lookup_operations.test.ts
+++ b/src/tests/lookup_operations.test.ts
@@ -45,7 +45,6 @@ const insertedKeys: {
 
 describe("Lookup Operations", () => {
   before(async () => {
-    await schema.createInstance("default").run();
     await ordersTable.delete().run();
     await usersTable.delete().run();
     await productsTable.delete().run();
@@ -55,7 +54,6 @@ describe("Lookup Operations", () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();
     await productsTable.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/merge_operations.test.ts
+++ b/src/tests/merge_operations.test.ts
@@ -39,15 +39,12 @@ const insertedKeys: {
 };
 
 describe("Merge Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();
     await productsTable.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/merge_operations.test.ts
+++ b/src/tests/merge_operations.test.ts
@@ -39,8 +39,6 @@ const insertedKeys: {
 };
 
 describe("Merge Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await ordersTable.delete().run();
     await usersTable.delete().run();

--- a/src/tests/row_level_operations.test.ts
+++ b/src/tests/row_level_operations.test.ts
@@ -9,8 +9,7 @@ const vehiclesTableName = "vehicles";
 
 const singleTableSchema = new Schema<{ [vehiclesTableName]: Vehicle }>(
   "test-rl-ops",
-  { [vehiclesTableName]: Vehicle },
-  { rowLevel: true },
+  { [vehiclesTableName]: { ...Vehicle, tenantScoped: true } },
 );
 
 const t1Vehicles = singleTableSchema.instance("t1").table(vehiclesTableName);
@@ -24,15 +23,11 @@ const multiTableSchema = new Schema<{
   [ordersTableName]: Order;
   [usersTableName]: User;
   [productsTableName]: Product;
-}>(
-  "test-rl-multi",
-  {
-    [ordersTableName]: Order,
-    [usersTableName]: User,
-    [productsTableName]: Product,
-  },
-  { rowLevel: true },
-);
+}>("test-rl-multi", {
+  [ordersTableName]: { ...Order, tenantScoped: true },
+  [usersTableName]: { ...User, tenantScoped: true },
+  [productsTableName]: { ...Product, tenantScoped: true },
+});
 
 const t1Orders = multiTableSchema.instance("t1").table(ordersTableName);
 const t1Users = multiTableSchema.instance("t1").table(usersTableName);

--- a/src/tests/sorting.test.ts
+++ b/src/tests/sorting.test.ts
@@ -14,8 +14,6 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Sorting Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await table.delete().run();
   });

--- a/src/tests/sorting.test.ts
+++ b/src/tests/sorting.test.ts
@@ -14,13 +14,10 @@ const testData = getUniqueUsers();
 let insertedKeys: string[] = [];
 
 describe("Sorting Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await table.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);

--- a/src/tests/union_operations.test.ts
+++ b/src/tests/union_operations.test.ts
@@ -29,8 +29,6 @@ const insertedKeys: {
 };
 
 describe("Union Operations", () => {
-  before(async () => {});
-
   after(async () => {
     await usersTable.delete().run();
     await productsTable.delete().run();

--- a/src/tests/union_operations.test.ts
+++ b/src/tests/union_operations.test.ts
@@ -29,14 +29,11 @@ const insertedKeys: {
 };
 
 describe("Union Operations", () => {
-  before(async () => {
-    await schema.createInstance("default").run();
-  });
+  before(async () => {});
 
   after(async () => {
     await usersTable.delete().run();
     await productsTable.delete().run();
-    await schema.destroyInstance("default").run();
   });
 
   it("Insert Test Data", InsertTestData);


### PR DESCRIPTION
## Summary

- Replace schema-wide `rowLevel` with a per-table `TableDefinition.tenantScoped` flag, so tenancy can be mixed within a single schema.
- Replace opaque `instance(id)` semantics with a `TenantId = string | typeof CROSS_TENANT` parameter; remove `createInstance`/`destroyInstance` since instances are no longer materialized resources.
- Add `CROSS_TENANT` sentinel as an admin escape hatch (skip filter on read/update/delete, reject on insert).
- Add `SchemaOptions.physicalStore` so multiple schemas can share the same physical database and enable native cross-schema joins.
- Bump test MongoDB binary to `@antelopejs/mongodb@1.0.7` and update all test suites to the new API.

## Breaking changes

- `SchemaOptions.rowLevel` removed → migrate to `tenantScoped` on each table that needs tenant isolation.
- `Schema.createInstance` / `Schema.destroyInstance` removed → no replacement needed; just call `schema.instance(tenantId)`.

## Test plan

- [ ] `pnpm test` passes against `@antelopejs/mongodb@1.0.7`
- [ ] `Tenant-Scoped Tables` suite covers: missing tenant throws, insert stamps `tenant_id`, tenant isolation, `CROSS_TENANT` reads see all tenants, `CROSS_TENANT` insert throws
- [ ] `Global Tables` suite covers CRUD without tenant context and that tenant ids are ignored on non-scoped tables

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the schema-wide `rowLevel` option and `createInstance`/`destroyInstance` lifecycle methods with a per-table `tenantScoped` flag, a `CROSS_TENANT` sentinel symbol, and a unified `instance(id?: TenantId)` API, enabling mixed tenancy within a single schema. It also adds `SchemaOptions.physicalStore` to allow multiple schemas to share one physical database, bumps the test MongoDB binary, and fully rewrites the instance-mode test suite to cover the new semantics.

- `CROSS_TENANT` is a `unique symbol` with thorough JSDoc detailing its JSON-serialization limitation and the identity-comparison contract, addressing the in-process-only constraint clearly.
- `row_level_operations.test.ts` retains its comprehensive per-tenant CRUD coverage; `instance_modes.test.ts` adds `TenantCrossUpdate` and `TenantCrossDelete` tests for the new cross-tenant escape hatch.
- Sub-path exports (`./common`, `./schema`, etc.) are added to `package.json`, making adapter-building blocks accessible to downstream implementors.

<h3>Confidence Score: 5/5</h3>

The interface changes are clean and the new CROSS_TENANT sentinel is well-documented; the main test gap is that TenantCrossUpdate only validates two of the three tenants present at test time.

The core schema.ts changes introduce no logic errors — CROSS_TENANT is correctly typed as a unique symbol, TenantId is properly defined, and physicalStore has a clear fallback. The test rewrite covers the new contract thoroughly, with the only gap being that TenantCrossUpdate does not verify the 'cleanup' tenant's rows after the cross-tenant update.

src/tests/instance_modes.test.ts (TenantCrossUpdate coverage) and src/antelope.test.ts (version discrepancy)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/schema.ts | Core API overhaul: removes rowLevel/createInstance/destroyInstance, adds per-table tenantScoped flag, CROSS_TENANT sentinel with detailed JSDoc, TenantId type, and physicalStore option. No logic bugs found. |
| src/index.ts | Exports CROSS_TENANT and TenantId — straightforward additions matching the schema.ts changes. |
| src/tests/instance_modes.test.ts | Replaces old db-level / row-level instance tests with Global Tables and Tenant-Scoped Tables suites; adds TenantCrossUpdate and TenantCrossDelete tests, but TenantCrossUpdate only validates t1/t2 docs rather than all tenants in the table. |
| src/tests/row_level_operations.test.ts | Migrated from schema-wide rowLevel flag to per-table tenantScoped spreads; comprehensive existing test cases retained and still correct. |
| src/antelope.test.ts | Bumps MongoDB test binary version from 1.0.5 to 1.1.0, but the PR description states the target is 1.0.7 — a discrepancy that should be reconciled. |
| package.json | Adds sub-path exports for all internal modules (common, datum, query, schema, selection, stream, valueproxy), enabling adapter implementors to import building blocks directly. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer
    participant Schema
    participant SchemaInstance
    participant Table
    participant Adapter

    Consumer->>Schema: instance(tenantId?)
    Schema->>SchemaInstance: "stage("instance", { id: tenantId })"
    Consumer->>SchemaInstance: table(name)
    SchemaInstance->>Table: "stage("table", { id: name })"

    alt "tenantId === undefined"
        Consumer->>Table: any operation
        Table->>Adapter: execute stage pipeline
        Adapter-->>Consumer: throws (tenant required on tenantScoped table)
    else "tenantId = "abc""
        Consumer->>Table: insert / read / update / delete
        Table->>Adapter: execute with tenant filter for "abc"
        Adapter-->>Consumer: result scoped to tenant "abc"
    else "tenantId === CROSS_TENANT"
        Consumer->>Table: read / update / delete
        Table->>Adapter: execute without tenant filter
        Adapter-->>Consumer: result across all tenants
        Consumer->>Table: insert
        Table->>Adapter: execute
        Adapter-->>Consumer: throws (cross-tenant insert rejected)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/antelope.test.ts:11-13
**Version in code doesn't match PR description**

The test config sets `version: "1.1.0"`, but the PR description states the bump targets `@antelopejs/mongodb@1.0.7`. If `1.1.0` introduces breaking changes relative to `1.0.7` (e.g., different behavior for the new tenant-scoped operations), tests could produce unexpected results without an obvious explanation. Please reconcile the version in the code with the one stated in the PR description.

### Issue 2 of 2
src/tests/instance_modes.test.ts:132-147
**`CROSS_TENANT` update is only verified for tenants t1 and t2**

At the time `TenantCrossUpdate` runs, the "cleanup" tenant also has a document in the table (inserted by `TenantInsertStamps`). The test asserts that the sentinel price is set on all t1 and t2 docs but never inspects the "cleanup" tenant's row. An implementation that excludes the "cleanup" tenant (or any tenant not explicitly checked here) from the cross-tenant update would pass this test. Adding a `CROSS_TENANT` read check after the update — e.g., asserting that every doc in `await crossTable.run()` has `price === sentinel` — would close this gap without extra plumbing.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: harden tenant-scoped tests, drop e..."](https://github.com/antelopejs/interface-database/commit/51ffa304938a51566e5390e0ecdef0b85d46dad0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31490118)</sub>

<!-- /greptile_comment -->