### PR TITLE
feat: accept io-ts codecs as table field types

### DIFF
--- a/docs/3.results/4.table_changes.md
+++ b/docs/3.results/4.table_changes.md
@@ -17,9 +17,25 @@ Field types describe the structure of each field:
 
 ```typescript
 type FieldType =
-  | string                          // Primitive type name (e.g., "string", "number")
-  | Array<FieldType>                // Array of a given type
-  | { [subfield: string]: FieldType }; // Nested object
+  | string                              // Primitive type name (e.g., "string", "number")
+  | Array<StringFieldType>              // Array of a given type
+  | { [subfield: string]: StringFieldType } // Nested object
+  | import("io-ts").Mixed;              // io-ts codec at the field root
+```
+
+A field can be described either with the string-token vocabulary (primitives, arrays, nested records) or with a single [io-ts](https://github.com/gcanti/io-ts) codec at the root of the field. Codecs are not mixed inside string-tree records — use io-ts combinators (`t.type`, `t.array`, …) to nest within a codec.
+
+```typescript
+import * as t from "io-ts";
+
+const Order = {
+  fields: {
+    id: "string",
+    status: t.union([t.literal("open"), t.literal("closed")]),
+    meta: t.type({ source: t.string, retries: t.number }),
+  },
+  indexes: {},
+};
 ```
 
 ## Define Tables in a Schema

--- a/package.json
+++ b/package.json
@@ -65,6 +65,14 @@
   "dependencies": {
     "@antelopejs/interface-core": "^0.0.3"
   },
+  "peerDependencies": {
+    "io-ts": "^2.2.0"
+  },
+  "peerDependenciesMeta": {
+    "io-ts": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
@@ -72,6 +80,8 @@
     "@types/node": "^22.19.15",
     "@types/semver": "^7.7.1",
     "chai": "^4.5.0",
+    "fp-ts": "^2.16.0",
+    "io-ts": "^2.2.0",
     "mongodb-memory-server-core": "^11.0.1",
     "release-it": "^19.2.4",
     "release-it-changelogen": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -65,14 +65,6 @@
   "dependencies": {
     "@antelopejs/interface-core": "^0.0.3"
   },
-  "peerDependencies": {
-    "io-ts": "^2.2.0"
-  },
-  "peerDependenciesMeta": {
-    "io-ts": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ importers:
       chai:
         specifier: ^4.5.0
         version: 4.5.0
+      fp-ts:
+        specifier: ^2.16.0
+        version: 2.16.11
+      io-ts:
+        specifier: ^2.2.0
+        version: 2.2.22(fp-ts@2.16.11)
       mongodb-memory-server-core:
         specifier: ^11.0.1
         version: 11.0.1(socks@2.8.7)
@@ -669,6 +675,9 @@ packages:
       debug:
         optional: true
 
+  fp-ts@2.16.11:
+    resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
+
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -739,6 +748,11 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  io-ts@2.2.22:
+    resolution: {integrity: sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==}
+    peerDependencies:
+      fp-ts: ^2.5.0
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -1940,6 +1954,8 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
+  fp-ts@2.16.11: {}
+
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
@@ -2030,6 +2046,10 @@ snapshots:
       rxjs: 7.8.2
     optionalDependencies:
       '@types/node': 22.19.15
+
+  io-ts@2.2.22(fp-ts@2.16.11):
+    dependencies:
+      fp-ts: 2.16.11
 
   ip-address@10.1.0: {}
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,5 @@
 import { RegisteringProxy } from "@antelopejs/interface-core";
+import type { Mixed } from "io-ts";
 import { QueryStage, StagedObject } from "./common";
 import { Query } from "./query";
 import { Table } from "./selection";
@@ -18,10 +19,12 @@ export interface IndexDefinition {
   multi?: boolean;
 }
 
-export type FieldType =
+type StringFieldType =
   | string
-  | Array<FieldType>
-  | { [subfield: string]: FieldType };
+  | Array<StringFieldType>
+  | { [subfield: string]: StringFieldType };
+
+export type FieldType = StringFieldType | Mixed;
 
 /**
  * Schema table definition

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,4 @@
 import { RegisteringProxy } from "@antelopejs/interface-core";
-import type { Mixed } from "io-ts";
 import { QueryStage, StagedObject } from "./common";
 import { Query } from "./query";
 import { Table } from "./selection";
@@ -19,12 +18,22 @@ export interface IndexDefinition {
   multi?: boolean;
 }
 
-type StringFieldType =
+export type StringFieldType =
   | string
   | Array<StringFieldType>
   | { [subfield: string]: StringFieldType };
 
-export type FieldType = StringFieldType | Mixed;
+interface IoTsCodec {
+  readonly _A: unknown;
+  readonly _O: unknown;
+  readonly _I: unknown;
+  readonly name: string;
+  is(u: unknown): boolean;
+  encode(a: never): unknown;
+  decode(i: unknown): unknown;
+}
+
+export type FieldType = StringFieldType | IoTsCodec;
 
 /**
  * Schema table definition

--- a/src/tests/datasets/codec_fields.ts
+++ b/src/tests/datasets/codec_fields.ts
@@ -1,0 +1,16 @@
+import * as t from "io-ts";
+import type { SchemaDefinition } from "../../schema";
+
+export const definition: SchemaDefinition = {
+  orders: {
+    fields: {
+      id: "string",
+      status: t.union([t.literal("open"), t.literal("closed")]),
+      meta: t.type({ source: t.string, retries: t.number }),
+      tags: "string[]",
+    },
+    indexes: {
+      status: {},
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Widen `FieldType` in `src/schema.ts` to accept any io-ts-shaped codec at the root of a field, alongside the existing string-token vocabulary. Codecs do not nest inside string-tree records — use io-ts combinators (`t.type`, `t.array`, …) for nesting within a codec.
- The codec arm is expressed as a local structural interface (`_A/_O/_I/name/is/encode/decode`) so the emitted `.d.ts` is self-contained; consumers don't need `io-ts` resolvable to use `FieldType`.
- Export `StringFieldType` alongside `FieldType` for consumers that want to spell the string-only arm.
- Update `docs/3.results/4.table_changes.md` with the codec arm and a short example.
- Add `src/tests/datasets/codec_fields.ts` as a compile-time check that codec-flavored schemas type-check.

The interface remains a thin pass-through — no runtime validation is added here; codecs flow through `Schemas.register` to adapters.

## Test plan
- [ ] `pnpm install` succeeds
- [ ] `pnpm run build` succeeds and `dist/schema.d.ts` has no `import("io-ts")` reference
- [ ] `pnpm run lint` is clean
- [ ] Existing string-token datasets (`src/tests/datasets/users.ts`, `products.ts`) still type-check unchanged (non-breaking)
- [ ] New `src/tests/datasets/codec_fields.ts` type-checks without `as any` or suppressions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR widens `FieldType` in `src/schema.ts` to accept io-ts codecs alongside the existing string-token vocabulary, using a self-contained local structural interface (`IoTsCodec`) so `io-ts` does not appear as an import in the emitted `.d.ts`. `StringFieldType` is now exported for consumers who need to reference the string-only arm explicitly.

- **`src/schema.ts`**: Renames the original `FieldType` to `StringFieldType` (now exported), introduces a local `IoTsCodec` structural interface, and re-exports `FieldType = StringFieldType | IoTsCodec` — no io-ts import, keeping the emitted declaration self-contained.
- **`src/tests/datasets/codec_fields.ts`**: New compile-time test confirming that io-ts codecs type-check correctly as field values inside a `SchemaDefinition`.
- **`package.json` / `pnpm-lock.yaml`**: Adds `fp-ts` and `io-ts` as devDependencies so the new test dataset compiles in CI.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and non-breaking; existing string-token schemas are unaffected.

The structural `IoTsCodec` interface correctly avoids any io-ts import in the emitted declaration, the string-token path is unchanged, and the new compile-time test dataset validates the codec arm. The two findings are minor documentation and export surface observations that don't affect runtime correctness.

The documentation in `docs/3.results/4.table_changes.md` references `import("io-ts").Mixed` rather than the actual local structural type, which is worth correcting before the docs are published.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/schema.ts | Introduces local structural `IoTsCodec` interface and `StringFieldType` alias; widens `FieldType` to accept codecs without importing from io-ts. `IoTsCodec` is not exported (minor). |
| docs/3.results/4.table_changes.md | Documents the new codec arm as `import("io-ts").Mixed` which doesn't match the actual local structural interface in the emitted `.d.ts`. |
| src/tests/datasets/codec_fields.ts | Compile-time test dataset validating that io-ts codecs type-check correctly against `SchemaDefinition`; looks correct. |
| package.json | Adds `fp-ts` and `io-ts` as devDependencies so the compile-time test dataset builds correctly. |

</details>

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class StringFieldType {
        <<type>>
        string
        Array~StringFieldType~
        Record~string, StringFieldType~
    }

    class IoTsCodec {
        <<interface>>
        +readonly _A: unknown
        +readonly _O: unknown
        +readonly _I: unknown
        +readonly name: string
        +is(u: unknown) boolean
        +encode(a: never) unknown
        +decode(i: unknown) unknown
    }

    class FieldType {
        <<type>>
        StringFieldType | IoTsCodec
    }

    class TableDefinition {
        <<interface>>
        +fields: Record~string, FieldType~
        +indexes: Record~string, IndexDefinition~
    }

    class SchemaDefinition {
        <<interface>>
        +[tableName: string]: TableDefinition
    }

    FieldType ..> StringFieldType : union arm
    FieldType ..> IoTsCodec : union arm
    TableDefinition --> FieldType : fields values
    SchemaDefinition --> TableDefinition : table values
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/3.results/4.table_changes.md:22-25
**Documentation type doesn't match the actual implementation**

The rendered `FieldType` in the docs references `import("io-ts").Mixed`, but the real exported type uses a local structural interface `IoTsCodec` with no import from `io-ts`. This misrepresents the contract to consumers: readers of the docs may think `io-ts` is a required transitive dependency for the type to exist, while the actual design deliberately avoids that. The codec arm should be documented as the local structural shape (or simply as "an io-ts-compatible codec object") to stay consistent with what `dist/schema.d.ts` will actually contain.

### Issue 2 of 2
src/schema.ts:26
`IoTsCodec` is the codec arm of the public `FieldType` union, but it is not exported. Consumers who want to write a helper or type guard that specifically accepts only the codec branch — not the full `FieldType` — have no way to reference it. `StringFieldType` was correctly exported for the same reason; exporting `IoTsCodec` keeps the public API surface symmetric.

```suggestion
export interface IoTsCodec {
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/interface-database/commit/547c9026bfb64f2edae27cf9bf0f5292f58619e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33005707)</sub>

<!-- /greptile_comment -->