### PR TITLE
feat(selection): accept ValueProxy keys in Table.get and Table.getAll

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -7,7 +7,9 @@ import type {
 import { Datum } from "./datum";
 import { Query } from "./query";
 import { Stream } from "./stream";
-import { ValueProxy } from "./valueproxy";
+import { ValueProxy, type ValueProxyOrValue } from "./valueproxy";
+
+type SelectionKey = string | number | boolean;
 
 /**
  * Selection containing a single element
@@ -133,7 +135,7 @@ export class Table<T> extends Selection<T> {
    * @param key Primary key value
    * @returns Single document selection
    */
-  public get(key: string) {
+  public get(key: ValueProxyOrValue<string>) {
     return this.stage(SingleSelection<T>, "get", undefined, key);
   }
 
@@ -145,7 +147,7 @@ export class Table<T> extends Selection<T> {
    * @returns Multiple document selection
    */
   public getAll(
-    keys: string | number | boolean | (string | number | boolean)[],
+    keys: ValueProxyOrValue<SelectionKey> | ValueProxyOrValue<SelectionKey>[],
     index?: string,
   ) {
     return this.stage(Selection<T>, "getAll", { index }, keys);


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Widens the typing of `Table.get` and `Table.getAll` selection keys to accept `ValueProxy` values, matching the existing runtime contract.

- `get(key: string)` → `get(key: ValueProxyOrValue<string>)`
- `getAll(keys: string | number | boolean | (...)[])` → `getAll(keys: ValueProxyOrValue<SelectionKey> | ValueProxyOrValue<SelectionKey>[], index?: string)`

The mongodb driver already decodes each stage argument via `DecodeValue` (`value instanceof ValueProxy` → `Expression.decode`), and `stage_get`/`stage_getAll` have a dedicated `needsExpr` branch emitting `$match: {$expr: {$eq: [...]}}` for non-literal keys. Consumers currently have to cast (e.g. `table.getAll(id as string, index)` or `row.key("_id") as unknown as string` for correlated subqueries) — this change removes those casts. Verified working against `@antelopejs/mongodb` 1.2.1.

Type-only change: the methods still pass arguments through to `this.stage(...)` unchanged. The array case remains valid since `stage_getAll` decodes each element individually. Build, lint and the 161 tests pass.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a type-only change that widens the `key` / `keys` parameters of `Table.get` and `Table.getAll` to accept `ValueProxy`-wrapped values in addition to plain scalars, removing the need for manual casts in correlated-subquery patterns.

- `Table.get` changes from `key: string` to `key: ValueProxyOrValue<string>`, matching the runtime's existing `DecodeValue` path.
- `Table.getAll` replaces the inline union `string | number | boolean | (...)[]` with `ValueProxyOrValue<SelectionKey> | ValueProxyOrValue<SelectionKey>[]`, where `SelectionKey` is a new local alias for `string | number | boolean`. Both the single-value and array cases remain structurally identical to the old type at the literal-value level.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change touches only TypeScript type signatures with no runtime logic altered.

Both method bodies are unchanged; the new types are strict supersets of the old ones, so all existing call sites remain valid. The introduced SelectionKey alias is a local type with no export surface. The widened signatures correctly reflect what the underlying driver already handles at runtime.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/selection.ts | Type-only widening of Table.get and Table.getAll to accept ValueProxy-wrapped keys alongside plain scalar values; a new SelectionKey type alias is introduced for readability. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Table
    participant stage
    participant Driver

    Note over Caller,Driver: get() with ValueProxy key
    Caller->>Table: "get(valueProxy: ValueProxy<string>)"
    Table->>stage: stage(SingleSelection, "get", undefined, valueProxy)
    stage->>Driver: DecodeValue(valueProxy) → Expression.decode
    Driver-->>Caller: "SingleSelection<T> via $match $expr $eq"

    Note over Caller,Driver: get() with plain string key (unchanged)
    Caller->>Table: get(key: string)
    Table->>stage: stage(SingleSelection, "get", undefined, key)
    stage->>Driver: DecodeValue(key) → literal
    Driver-->>Caller: "SingleSelection<T> via $match _id"

    Note over Caller,Driver: getAll() with mixed proxy/value array
    Caller->>Table: getAll([proxy, "literal"], index?)
    Table->>stage: "stage(Selection, "getAll", {index}, keys)"
    stage->>Driver: DecodeValue per element
    Driver-->>Caller: "Selection<T>"
```

<sub>Reviews (1): Last reviewed commit: ["feat(selection): accept ValueProxy keys ..."](https://github.com/antelopejs/interface-database/commit/79b304ea0f2fe8a1d11c8245a482cb37ac2ab5c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37264652)</sub>

<!-- /greptile_comment -->