### PR TITLE
chore(deps): interface-core as bounded peer + dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,8 @@
     "release": "pnpm run lint && pnpm run prepack && release-it",
     "test": "pnpm run build && ajs module test ."
   },
-  "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3"
-  },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -79,6 +77,9 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,10 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
Move `@antelopejs/interface-core` from dependencies to peerDependencies (bounded to the current major, e.g. `>=0.0.5 <0.1.0`) and mirror it in devDependencies for standalone compilation. interface-core is a host-provided runtime singleton; this avoids dual installs and version-pinning overrides downstream. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `@antelopejs/interface-core` from `dependencies` to `peerDependencies` (mirrored in `devDependencies`) to avoid duplicate installs and version-pinning conflicts in downstream consumers — a correct architectural direction for a host-provided singleton.

- Both `peerDependencies` and `devDependencies` use `>=0.0.3 <1.0.0`, but the PR description states the intent as `<0.1.0`; the wider `<1.0.0` bound accepts every `0.x` minor release, which is where breaking changes land for a pre-`0.1` package.
- The lock file correctly moves the pinned `0.0.3` resolution from `dependencies` to `devDependencies` with no other changes.

<h3>Confidence Score: 4/5</h3>

The architectural change (moving to peerDependencies) is correct, but both ranges use <1.0.0 instead of the <0.1.0 the PR description describes as the intent, leaving the door open to incompatible minor releases of interface-core.

The range >=0.0.3 <1.0.0 accepts future 0.1.x, 0.2.x, etc. releases of a package still in 0.0.x, where minor bumps are the natural place for breaking API changes. The stated goal was to stay within the current minor series (<0.1.0), and the implementation diverges from that intent in both peerDependencies and devDependencies.

package.json — the version range upper bound needs to be tightened from <1.0.0 to <0.1.0 in both dependency sections.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves @antelopejs/interface-core to peerDependencies + devDependencies, but the range `>=0.0.3 <1.0.0` is broader than the intended `<0.1.0` stated in the PR description, potentially accepting breaking minor-version changes. |
| pnpm-lock.yaml | Lock file updated to reflect the move from dependencies to devDependencies; pinned version remains 0.0.3. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[interface-database published] --> B{dependency type}
    B -->|Before PR| C["dependencies: @antelopejs/interface-core ^0.0.3 - bundled into consumer node_modules"]
    B -->|After PR| D["peerDependencies: >=0.0.3 <1.0.0 - host must provide"]
    D --> E["devDependencies: >=0.0.3 <1.0.0 - installed locally for build and test"]
    C --> F[Risk: dual install and version-pin conflicts downstream]
    D --> G[Benefit: single instance, no version override]
    E --> H[pnpm resolves 0.0.3 in lock file]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[interface-database published] --> B{dependency type}
    B -->|Before PR| C["dependencies: @antelopejs/interface-core ^0.0.3 - bundled into consumer node_modules"]
    B -->|After PR| D["peerDependencies: >=0.0.3 <1.0.0 - host must provide"]
    D --> E["devDependencies: >=0.0.3 <1.0.0 - installed locally for build and test"]
    C --> F[Risk: dual install and version-pin conflicts downstream]
    D --> G[Benefit: single instance, no version override]
    E --> H[pnpm resolves 0.0.3 in lock file]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-database/commit/f7634028e106abf17d4f3b81bad559572bdf2869) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739011)</sub>

<!-- /greptile_comment -->